### PR TITLE
Setup for confirming the rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: rust
+before_script:
+  - rustup component add rustfmt-preview
+script:
+  - cargo fmt --all -- --write-mode=diff
+  - cargo build
+  - cargo test
 rust:
   - stable
-  - beta
-  - nightly


### PR DESCRIPTION
Remove testing for anything other than stable. We should desire to pass
on nightly and others but for now we can target stable. The reason is
that the rustfmt crate is not entirely stable so some functionality is
different on stable versus nightly. Also, add a rustfmt.toml to enforce
styles that we want in the future. It's empty right now.

closes #6 