### PR TITLE
Endpoint trait should map to http request struct.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Kevin Bacha <chewbacha@gmail.com>"]
 
 [dependencies]
 stellar-resources = { path = "../resources" }
+http = "0.1"
 hyper = "0.11"
 hyper-tls = "0.1"
 tokio-core = "0.1"

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -1,14 +1,15 @@
 //! This module contains the various end point definitions for stellar's horizon
 //! API server.
 use error::Result;
-use hyper::Uri;
 use serde::Deserialize;
+use http;
 
 mod account;
 pub use self::account::AccountDetails;
 
 pub(crate) trait EndPoint<'de> {
     type Response: Deserialize<'de>;
+    type RequestBody;
 
-    fn to_uri(&self, host: &str) -> Result<Uri>;
+    fn into_request(self, host: &str) -> Result<http::Request<Self::RequestBody>>;
 }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -2,6 +2,7 @@
 use std::error::Error as StdError;
 use hyper::error::UriError;
 use hyper;
+use http;
 use std::fmt;
 
 /// A set of errors for use in the client
@@ -11,7 +12,12 @@ pub enum Error {
     BadUri,
     /// Was unable to resolve ssl configuration
     BadSSL,
-
+    /// The response was from the http library and resulted in an error.
+    /// this type does not map down well and currently is just wrapped
+    /// generically. See the inner description for details.
+    ///
+    /// https://github.com/hyperium/http/issues/188
+    Http(http::Error),
     #[doc(hidden)] __Nonexhaustive,
 }
 
@@ -23,6 +29,7 @@ impl StdError for Error {
         match *self {
             Error::BadUri => "An invalid uri was specified when constructing the client",
             Error::BadSSL => "Unable to resolve tls",
+            Error::Http(ref inner) => inner.description(),
             Error::__Nonexhaustive => unreachable!(),
         }
     }
@@ -43,5 +50,33 @@ impl From<UriError> for Error {
 impl From<hyper::Error> for Error {
     fn from(_: hyper::Error) -> Self {
         Error::BadUri
+    }
+}
+
+impl From<http::Error> for Error {
+    fn from(inner: http::Error) -> Self {
+        Error::Http(inner)
+    }
+}
+
+impl From<http::uri::InvalidUri> for Error {
+    fn from(_: http::uri::InvalidUri) -> Self {
+        Error::BadUri
+    }
+}
+
+#[cfg(test)]
+mod error_coversion_tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn it_coerces_an_http_parse_failure() {
+        let error = http::Uri::from_str("b l a h").unwrap_err();
+        let error: Error = error.into();
+        assert_eq!(
+            error.description(),
+            "An invalid uri was specified when constructing the client"
+        );
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -2,6 +2,7 @@
 //! Client implementation to the stellar horizon api.
 
 extern crate futures;
+extern crate http;
 extern crate hyper;
 extern crate hyper_tls;
 extern crate serde;


### PR DESCRIPTION
This adds the request body as an associated type to the endpoint. In
some cases this will be a unit (as with the account details that lacks a
body). Other than that, this also maps some of the error types from http
into our own.

resolves #37 