### PR TITLE
Implement Sync Client

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 authors = ["Kevin Bacha <chewbacha@gmail.com>"]
 
 [dependencies]
-stellar-resources = { path = "../resources" }
+futures = "0.1"
 http = "0.1"
 hyper = "0.11"
 hyper-tls = "0.1"
-tokio-core = "0.1"
-futures = "0.1"
+reqwest = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+stellar-resources = { path = "../resources" }
+tokio-core = "0.1"

--- a/client/src/client/async.rs
+++ b/client/src/client/async.rs
@@ -1,0 +1,169 @@
+//! This module contains the client for asynchronous communcation.
+
+use hyper;
+use hyper_tls::HttpsConnector;
+use http;
+use tokio_core::reactor::Handle;
+use error::{Error, Result};
+use super::{Host, HORIZON_TEST_URI, HORIZON_URI};
+
+/// A client that can issue requests to a horizon api.
+#[derive(Debug, Clone)]
+pub struct Client {
+    inner: hyper::Client<HttpsConnector<hyper::client::HttpConnector>>,
+    host: Host,
+}
+
+impl Client {
+    /// Constructs a new stellar client.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # extern crate tokio_core;
+    /// # extern crate stellar_client;
+    /// # fn main() {
+    /// use tokio_core::reactor::Core;
+    /// use stellar_client::async::Client;
+    /// let core = Core::new().unwrap();
+    /// let client = Client::new("https://horizon-testnet.stellar.org", &core.handle()).unwrap();
+    /// # }
+    /// ```
+    pub fn new(uri: &str, handle: &Handle) -> Result<Self> {
+        // Ensure that the uri passed in can parse.
+        let _: http::Uri = uri.parse()?;
+        Self::build(Host::Other(uri.to_string()), &handle)
+    }
+
+    fn build(host: Host, handle: &Handle) -> Result<Self> {
+        let inner = hyper::Client::configure()
+            .connector(HttpsConnector::new(4, &handle).map_err(|_| Error::BadSSL)?)
+            .build(&handle);
+        Ok(Client { host, inner })
+    }
+
+    /// Constructs a new stellar client connected to the horizon test network.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # extern crate tokio_core;
+    /// # extern crate stellar_client;
+    /// # fn main() {
+    /// use tokio_core::reactor::Core;
+    /// use stellar_client::async::Client;
+    /// let core = Core::new().unwrap();
+    /// let client = Client::horizon_test(&core.handle()).unwrap();
+    /// # }
+    /// ```
+    pub fn horizon_test(handle: &Handle) -> Result<Self> {
+        Self::build(Host::HorizonTest, &handle)
+    }
+
+    /// Returns true if this is a test client.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # extern crate tokio_core;
+    /// # extern crate stellar_client;
+    /// # fn main() {
+    /// # use tokio_core::reactor::Core;
+    /// # use stellar_client::async::Client;
+    /// # let core = Core::new().unwrap();
+    /// let client = Client::horizon_test(&core.handle()).unwrap();
+    /// assert!(!client.is_horizon());
+    /// assert!(client.is_horizon_test());
+    /// # }
+    /// ```
+    pub fn is_horizon_test(&self) -> bool {
+        self.host == Host::HorizonTest
+    }
+
+    /// Constructs a new stellar client connected to the horizon test network.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # extern crate tokio_core;
+    /// # extern crate stellar_client;
+    /// # fn main() {
+    /// use tokio_core::reactor::Core;
+    /// use stellar_client::async::Client;
+    /// let core = Core::new().unwrap();
+    /// let client = Client::horizon(&core.handle()).unwrap();
+    /// # }
+    /// ```
+    pub fn horizon(handle: &Handle) -> Result<Self> {
+        Self::build(Host::HorizonProd, &handle)
+    }
+
+    /// Returns true if this is a horizon@stellar client.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # extern crate tokio_core;
+    /// # extern crate stellar_client;
+    /// # fn main() {
+    /// # use tokio_core::reactor::Core;
+    /// # use stellar_client::async::Client;
+    /// # let core = Core::new().unwrap();
+    /// let client = Client::horizon(&core.handle()).unwrap();
+    /// assert!(client.is_horizon());
+    /// assert!(!client.is_horizon_test());
+    /// # }
+    /// ```
+    pub fn is_horizon(&self) -> bool {
+        self.host == Host::HorizonProd
+    }
+
+    #[allow(dead_code)] // TODO: Used for joining to end points
+    fn uri<'a>(&'a self) -> &'a str {
+        match self.host {
+            Host::HorizonTest => HORIZON_TEST_URI,
+            Host::HorizonProd => HORIZON_URI,
+            Host::Other(ref uri) => uri,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_core::reactor::Core;
+
+    #[test]
+    fn it_constructs_a_test_client() {
+        let core = Core::new().unwrap();
+        let client = Client::horizon_test(&core.handle()).unwrap();
+        assert_eq!(client.host, Host::HorizonTest);
+        assert_eq!(client.uri(), "https://horizon-testnet.stellar.org");
+    }
+
+    #[test]
+    fn it_constructs_a_horizon_client() {
+        let core = Core::new().unwrap();
+        let client = Client::horizon(&core.handle()).unwrap();
+        assert_eq!(client.host, Host::HorizonProd);
+        assert_eq!(client.uri(), "https://horizon.stellar.org");
+    }
+
+    #[test]
+    fn it_constructs_a_client_to_other() {
+        let core = Core::new().unwrap();
+        let client = Client::new("https://www.google.com", &core.handle()).unwrap();
+        assert_eq!(
+            client.host,
+            Host::Other("https://www.google.com".to_string())
+        );
+        assert_eq!(client.uri(), "https://www.google.com");
+    }
+
+    #[test]
+    fn it_errs_if_a_bad_uri_is_provided() {
+        let core = Core::new().unwrap();
+        let result = Client::new("htps:/www", &core.handle());
+        assert!(result.is_err());
+    }
+}

--- a/client/src/client/mod.rs
+++ b/client/src/client/mod.rs
@@ -1,8 +1,10 @@
-use hyper;
-use hyper_tls::HttpsConnector;
-use tokio_core::reactor::Handle;
-use error::{Error, Result};
-
+//! This modulbe encompasses the major clients for the stellar sdk. It's
+//! basically divided into the synchronous client and the asynchronous. The
+//! synchronous client utilitizes `reqwest` under the hood and will block
+//! the current thread until a response has been received and processed.
+//!
+//! In contrast, the async client will return a future for execution on the
+//! event loop and will yield the returned resource as a result of a future.
 #[derive(Debug, Clone, PartialEq)]
 enum Host {
     HorizonTest,
@@ -10,166 +12,8 @@ enum Host {
     Other(String),
 }
 
-/// A client that can issue requests to a horizon api.
-#[derive(Debug, Clone)]
-pub struct Client {
-    inner: hyper::Client<HttpsConnector<hyper::client::HttpConnector>>,
-    host: Host,
-}
-
 static HORIZON_TEST_URI: &'static str = "https://horizon-testnet.stellar.org";
 static HORIZON_URI: &'static str = "https://horizon.stellar.org";
 
-impl Client {
-    /// Constructs a new stellar client.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// # extern crate tokio_core;
-    /// # extern crate stellar_client;
-    /// # fn main() {
-    /// use tokio_core::reactor::Core;
-    /// use stellar_client::Client;
-    /// let core = Core::new().unwrap();
-    /// let client = Client::new("https://horizon-testnet.stellar.org", &core.handle()).unwrap();
-    /// # }
-    /// ```
-    pub fn new(uri: &str, handle: &Handle) -> Result<Self> {
-        // Ensure that the uri passed in can parse.
-        let _: hyper::Uri = uri.parse().map_err(|_| Error::BadUri)?;
-        Self::build(Host::Other(uri.to_string()), &handle)
-    }
-
-    fn build(host: Host, handle: &Handle) -> Result<Self> {
-        let inner = hyper::Client::configure()
-            .connector(HttpsConnector::new(4, &handle).map_err(|_| Error::BadSSL)?)
-            .build(&handle);
-        Ok(Client { host, inner })
-    }
-
-    /// Constructs a new stellar client connected to the horizon test network.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// # extern crate tokio_core;
-    /// # extern crate stellar_client;
-    /// # fn main() {
-    /// use tokio_core::reactor::Core;
-    /// use stellar_client::Client;
-    /// let core = Core::new().unwrap();
-    /// let client = Client::horizon_test(&core.handle()).unwrap();
-    /// # }
-    /// ```
-    pub fn horizon_test(handle: &Handle) -> Result<Self> {
-        Self::build(Host::HorizonTest, &handle)
-    }
-
-    /// Returns true if this is a test client.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// # extern crate tokio_core;
-    /// # extern crate stellar_client;
-    /// # fn main() {
-    /// # use tokio_core::reactor::Core;
-    /// # use stellar_client::Client;
-    /// # let core = Core::new().unwrap();
-    /// let client = Client::horizon_test(&core.handle()).unwrap();
-    /// assert!(!client.is_horizon());
-    /// assert!(client.is_horizon_test());
-    /// # }
-    /// ```
-    pub fn is_horizon_test(&self) -> bool {
-        self.host == Host::HorizonTest
-    }
-
-    /// Constructs a new stellar client connected to the horizon test network.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// # extern crate tokio_core;
-    /// # extern crate stellar_client;
-    /// # fn main() {
-    /// use tokio_core::reactor::Core;
-    /// use stellar_client::Client;
-    /// let core = Core::new().unwrap();
-    /// let client = Client::horizon(&core.handle()).unwrap();
-    /// # }
-    /// ```
-    pub fn horizon(handle: &Handle) -> Result<Self> {
-        Self::build(Host::HorizonProd, &handle)
-    }
-
-    /// Returns true if this is a horizon@stellar client.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// # extern crate tokio_core;
-    /// # extern crate stellar_client;
-    /// # fn main() {
-    /// # use tokio_core::reactor::Core;
-    /// # use stellar_client::Client;
-    /// # let core = Core::new().unwrap();
-    /// let client = Client::horizon(&core.handle()).unwrap();
-    /// assert!(client.is_horizon());
-    /// assert!(!client.is_horizon_test());
-    /// # }
-    /// ```
-    pub fn is_horizon(&self) -> bool {
-        self.host == Host::HorizonProd
-    }
-
-    #[allow(dead_code)] // TODO: Used for joining to end points
-    fn uri<'a>(&'a self) -> &'a str {
-        match self.host {
-            Host::HorizonTest => HORIZON_TEST_URI,
-            Host::HorizonProd => HORIZON_URI,
-            Host::Other(ref uri) => uri,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tokio_core::reactor::Core;
-
-    #[test]
-    fn it_constructs_a_test_client() {
-        let core = Core::new().unwrap();
-        let client = Client::horizon_test(&core.handle()).unwrap();
-        assert_eq!(client.host, Host::HorizonTest);
-        assert_eq!(client.uri(), "https://horizon-testnet.stellar.org");
-    }
-
-    #[test]
-    fn it_constructs_a_horizon_client() {
-        let core = Core::new().unwrap();
-        let client = Client::horizon(&core.handle()).unwrap();
-        assert_eq!(client.host, Host::HorizonProd);
-        assert_eq!(client.uri(), "https://horizon.stellar.org");
-    }
-
-    #[test]
-    fn it_constructs_a_client_to_other() {
-        let core = Core::new().unwrap();
-        let client = Client::new("https://www.google.com", &core.handle()).unwrap();
-        assert_eq!(
-            client.host,
-            Host::Other("https://www.google.com".to_string())
-        );
-        assert_eq!(client.uri(), "https://www.google.com");
-    }
-
-    #[test]
-    fn it_errs_if_a_bad_uri_is_provided() {
-        let core = Core::new().unwrap();
-        let result = Client::new("htps:/www", &core.handle());
-        assert!(result.is_err());
-    }
-}
+pub mod async;
+pub mod sync;

--- a/client/src/client/sync.rs
+++ b/client/src/client/sync.rs
@@ -1,0 +1,189 @@
+//! This module contains the client for synchronous communcation.
+
+use reqwest;
+use http::{self, Uri};
+use error::{Error, Result};
+use endpoint::EndPoint;
+use super::{Host, HORIZON_TEST_URI, HORIZON_URI};
+use serde_json;
+
+/// A client that can issue requests to a horizon api in a synchronous
+/// fashion, meaning that the functions will block until the response
+/// has been formed. The overall performance of this is slightly slower
+/// than using async but will generally be simpler to implement.
+#[derive(Debug, Clone)]
+pub struct Client {
+    inner: reqwest::Client,
+    host: Host,
+}
+
+impl Client {
+    /// Constructs a new stellar synchronous client.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use stellar_client::sync::Client;
+    /// let client = Client::new("https://horizon-testnet.stellar.org").unwrap();
+    /// ```
+    pub fn new(uri: &str) -> Result<Self> {
+        // Ensure that the uri passed in can parse.
+        let _: Uri = uri.parse()?;
+        Self::build(Host::Other(uri.to_string()))
+    }
+
+    fn build(host: Host) -> Result<Self> {
+        let inner = reqwest::Client::new();
+        Ok(Client { host, inner })
+    }
+
+    /// Constructs a new stellar client connected to the horizon test network.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use stellar_client::sync::Client;
+    /// let client = Client::horizon_test().unwrap();
+    /// ```
+    pub fn horizon_test() -> Result<Self> {
+        Self::build(Host::HorizonTest)
+    }
+
+    /// Returns true if this is a test client.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use stellar_client::sync::Client;
+    /// let client = Client::horizon_test().unwrap();
+    /// assert!(!client.is_horizon());
+    /// assert!(client.is_horizon_test());
+    /// ```
+    pub fn is_horizon_test(&self) -> bool {
+        self.host == Host::HorizonTest
+    }
+
+    /// Constructs a new stellar client connected to the horizon test network.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use stellar_client::sync::Client;
+    /// let client = Client::horizon().unwrap();
+    /// ```
+    pub fn horizon() -> Result<Self> {
+        Self::build(Host::HorizonProd)
+    }
+
+    /// Returns true if this is a horizon@stellar client.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use stellar_client::sync::Client;
+    /// let client = Client::horizon().unwrap();
+    /// assert!(client.is_horizon());
+    /// assert!(!client.is_horizon_test());
+    /// ```
+    pub fn is_horizon(&self) -> bool {
+        self.host == Host::HorizonProd
+    }
+
+    #[allow(dead_code)] // TODO: Used for joining to end points
+    fn uri<'a>(&'a self) -> &'a str {
+        match self.host {
+            Host::HorizonTest => HORIZON_TEST_URI,
+            Host::HorizonProd => HORIZON_URI,
+            Host::Other(ref uri) => uri,
+        }
+    }
+
+    /// Issues a request to the stellar horizon server synchronously.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use stellar_client::sync::Client;
+    /// use stellar_client::endpoint::AccountDetails;
+    /// let client = Client::horizon_test().unwrap();
+    /// let endpoint =
+    ///     AccountDetails::new("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
+    /// let account = client.request(endpoint).unwrap();
+    /// assert_eq!(account.id(), "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
+    /// ```
+    pub fn request<E>(&self, endpoint: E) -> Result<E::Response>
+    where
+        E: EndPoint,
+    {
+        let request = endpoint.into_request(&self.uri())?;
+        let request = Self::http_to_reqwest(request);
+        let response = self.inner.execute(request)?;
+        if response.status().is_success() {
+            let resp: E::Response = serde_json::from_reader(response)?;
+            Ok(resp)
+        } else {
+            // TODO: Implement bad response parsing and capture the error here.
+            Err(Error::BadResponse)
+        }
+    }
+
+    fn http_to_reqwest<T>(request: http::Request<T>) -> reqwest::Request {
+        use http::method::Method;
+        let method = match *request.method() {
+            Method::GET => reqwest::Method::Get,
+            _ => unimplemented!(),
+        };
+        // infalliable because it's already passed the more strenuous http crate
+        // url parsing.
+        let url: reqwest::Url = format!("{}", request.uri()).parse().unwrap();
+        reqwest::Request::new(method, url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_constructs_a_test_client() {
+        let client = Client::horizon_test().unwrap();
+        assert_eq!(client.host, Host::HorizonTest);
+        assert_eq!(client.uri(), "https://horizon-testnet.stellar.org");
+    }
+
+    #[test]
+    fn it_constructs_a_horizon_client() {
+        let client = Client::horizon().unwrap();
+        assert_eq!(client.host, Host::HorizonProd);
+        assert_eq!(client.uri(), "https://horizon.stellar.org");
+    }
+
+    #[test]
+    fn it_constructs_a_client_to_other() {
+        let client = Client::new("https://www.google.com").unwrap();
+        assert_eq!(
+            client.host,
+            Host::Other("https://www.google.com".to_string())
+        );
+        assert_eq!(client.uri(), "https://www.google.com");
+    }
+
+    #[test]
+    fn it_errs_if_a_bad_uri_is_provided() {
+        let result = Client::new("htps:/www");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn it_can_make_a_request() {
+        use endpoint::AccountDetails;
+        let client = Client::horizon_test().unwrap();
+        let endpoint =
+            AccountDetails::new("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
+        let account = client.request(endpoint).unwrap();
+        assert_eq!(
+            account.id(),
+            "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ"
+        );
+    }
+}

--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -18,7 +18,7 @@ impl AccountDetails {
     }
 }
 
-impl<'de> EndPoint<'de> for AccountDetails {
+impl EndPoint for AccountDetails {
     type Response = Account;
     type RequestBody = ();
 

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -1,15 +1,19 @@
 //! This module contains the various end point definitions for stellar's horizon
 //! API server.
 use error::Result;
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use http;
 
 mod account;
 pub use self::account::AccountDetails;
 
-pub(crate) trait EndPoint<'de> {
-    type Response: Deserialize<'de>;
+/// Declares the definition of a stellar endpoint and the return type.
+pub trait EndPoint {
+    /// The deserializable type that is expected to come back from the stellar server.
+    type Response: DeserializeOwned;
+    /// The request body to be sent to stellar. Generally this is just a `()` unit.
     type RequestBody;
 
+    /// Converts the implementing struct into an http request.
     fn into_request(self, host: &str) -> Result<http::Request<Self::RequestBody>>;
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -5,6 +5,7 @@ extern crate futures;
 extern crate http;
 extern crate hyper;
 extern crate hyper_tls;
+extern crate reqwest;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -12,7 +13,7 @@ extern crate serde_json;
 extern crate stellar_resources;
 extern crate tokio_core;
 
-mod client;
+pub mod client;
 pub mod endpoint;
 pub mod error;
 mod stellar_error;
@@ -26,6 +27,6 @@ mod stellar_error;
 /// need to hand it the tokio handle and execute the futures on your own. Once tokio
 /// 0.2.0 is released with the global event loop, it will add them to the event loop
 /// itself.
-pub use client::Client;
+pub use client::{async, sync};
 pub use error::{Error, Result};
 pub use stellar_error::StellarError;


### PR DESCRIPTION
This commit implements the synchronous client library utilizing the
reqwest http client. It maps the end point into http and then converts
it to a reqwest request. This is then issued to the server and parsed
into the resulting response type correctly.

I've also divided up the client library into two components, the sync
and async module to allow easy choice between them. Generally the sync
will be useful for the CLI but async may be better for the actual web
server itself.

Lastly, I have written examples issuing a get query to the account
details end point :)