### PR TITLE
Implement the all assets end point

### DIFF
--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -1,0 +1,189 @@
+use error::Result;
+use std::str::FromStr;
+use stellar_resources::Asset;
+use super::{EndPoint, Order, Records};
+use http::{Request, Uri};
+
+/// Represents the all assets end point for the stellar horizon server. The endpoint
+/// will return all assets filtered by a myriad of different query params.
+///
+/// https://www.stellar.org/developers/horizon/reference/endpoints/assets-all.html
+///
+/// ## Examples
+///
+/// #### Asset code
+///
+/// Fetches all records for a given asset code.
+///
+/// ```
+/// # use stellar_client::sync::Client;
+/// # use stellar_client::endpoint::AllAssets;
+/// #
+/// let client      = Client::horizon_test().unwrap();
+/// let endpoint    = AllAssets::default().asset_code("USD");
+/// let records     = client.request(endpoint).unwrap();
+/// #
+/// # assert!(records.records().len() > 0);
+/// # assert_eq!(records.records()[0].code(), "USD");
+/// ```
+///
+/// #### Issuer
+///
+/// Fetches all records for a given asset issuer.
+///
+/// ```
+/// # use stellar_client::sync::Client;
+/// # use stellar_client::endpoint::AllAssets;
+/// #
+/// let client = Client::horizon_test().unwrap();
+/// # let endpoint = AllAssets::default().asset_code("USD");
+/// # let records = client.request(endpoint).unwrap();
+/// # let issuer = records.records()[0].issuer();
+/// let endpoint = AllAssets::default().asset_issuer(issuer);
+/// let records = client.request(endpoint).unwrap();
+/// #
+/// # assert!(records.records().len() > 0);
+/// # assert_eq!(records.records()[0].issuer(), issuer);
+/// ```
+///
+/// #### Order
+///
+/// Fetches all records in a set order, either ascending or descending.
+///
+/// ```
+/// # use stellar_client::sync::Client;
+/// # use stellar_client::endpoint::{AllAssets, Order};
+/// #
+/// let client      = Client::horizon_test().unwrap();
+/// let endpoint    = AllAssets::default().order(Order::Asc);
+/// let records     = client.request(endpoint).unwrap();
+/// #
+/// # assert!(records.records().len() > 0);
+/// ```
+///
+/// #### Limit
+///
+/// Fetches a set number of assets at a time
+///
+/// ```
+/// # use stellar_client::sync::Client;
+/// # use stellar_client::endpoint::AllAssets;
+/// #
+/// let client      = Client::horizon_test().unwrap();
+/// let endpoint    = AllAssets::default().limit(3);
+/// let records     = client.request(endpoint).unwrap();
+/// #
+/// # assert_eq!(records.records().len(), 3);
+/// ```
+#[derive(Debug, Default)]
+pub struct AllAssets {
+    code: Option<String>,
+    issuer: Option<String>,
+    // TODO: Cursor needs to be parseable from the links that come back
+    // for _next and _prev
+    cursor: Option<String>,
+    order: Option<Order>,
+    limit: Option<u32>,
+}
+
+impl AllAssets {
+    /// Sets the asset code query parameter
+    pub fn asset_code(mut self, code: &str) -> Self {
+        self.code = Some(code.to_string());
+        self
+    }
+
+    /// Sets the asset issuer query parameter
+    pub fn asset_issuer(mut self, issuer: &str) -> Self {
+        self.issuer = Some(issuer.to_string());
+        self
+    }
+
+    /// Sets the order to return the results in
+    pub fn order(mut self, order: Order) -> Self {
+        self.order = Some(order);
+        self
+    }
+
+    /// Sets the cursor to start at
+    pub fn cursor(mut self, cursor: &str) -> Self {
+        self.cursor = Some(cursor.to_string());
+        self
+    }
+
+    /// Sets the number of records to return at most.
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    fn has_query(&self) -> bool {
+        self.code.is_some() || self.issuer.is_some() || self.order.is_some()
+            || self.cursor.is_some() || self.limit.is_some()
+    }
+}
+
+impl EndPoint for AllAssets {
+    type Response = Records<Asset>;
+    type RequestBody = ();
+
+    fn into_request(self, host: &str) -> Result<Request<()>> {
+        let mut uri = format!("{}/assets", host);
+
+        if self.has_query() {
+            uri.push_str("?");
+            if let Some(code) = self.code {
+                uri.push_str(&format!("asset_code={}&", code));
+            }
+
+            if let Some(issuer) = self.issuer {
+                uri.push_str(&format!("asset_issuer={}&", issuer));
+            }
+
+            if let Some(order) = self.order {
+                uri.push_str(&format!("order={}&", order.to_param()));
+            }
+
+            if let Some(cursor) = self.cursor {
+                uri.push_str(&format!("cursor={}&", cursor));
+            }
+
+            if let Some(limit) = self.limit {
+                uri.push_str(&format!("limit={}", limit));
+            }
+        }
+
+        let uri = Uri::from_str(&uri)?;
+        let request = Request::get(uri).body(())?;
+        Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod all_assets_tests {
+    use super::*;
+
+    #[test]
+    fn it_leaves_off_the_params_if_not_specified() {
+        let ep = AllAssets::default();
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/assets");
+        assert_eq!(req.uri().query(), None);
+    }
+
+    #[test]
+    fn it_puts_the_query_params_on_the_uri() {
+        let ep = AllAssets::default()
+            .asset_code("CODE")
+            .asset_issuer("ISSUER")
+            .cursor("CURSOR")
+            .limit(123)
+            .order(Order::Desc);
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/assets");
+        assert_eq!(
+            req.uri().query(),
+            Some("asset_code=CODE&asset_issuer=ISSUER&order=desc&cursor=CURSOR&limit=123")
+        );
+    }
+}

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -1,11 +1,14 @@
 //! This module contains the various end point definitions for stellar's horizon
 //! API server.
 use error::Result;
-use serde::de::DeserializeOwned;
+use std;
+use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 use http;
 
 mod account;
+mod asset;
 pub use self::account::AccountDetails;
+pub use self::asset::AllAssets;
 
 /// Declares the definition of a stellar endpoint and the return type.
 pub trait EndPoint {
@@ -16,4 +19,97 @@ pub trait EndPoint {
 
     /// Converts the implementing struct into an http request.
     fn into_request(self, host: &str) -> Result<http::Request<Self::RequestBody>>;
+}
+
+/// The order to return results in.
+#[derive(Debug)]
+pub enum Order {
+    /// Order the results ascending
+    Asc,
+    /// Order the results descending
+    Desc,
+}
+
+impl Order {
+    pub(crate) fn to_param(&self) -> String {
+        match *self {
+            Order::Asc => "asc".to_string(),
+            Order::Desc => "desc".to_string(),
+        }
+    }
+}
+
+/// A struct that represents a set of records returned from the horizon api.
+#[derive(Debug)]
+pub struct Records<T>
+where
+    T: DeserializeOwned,
+{
+    records: Vec<T>,
+}
+
+impl<T> Records<T>
+where
+    T: DeserializeOwned,
+{
+    /// Returns a slice of the embedded records.
+    pub fn records<'a>(&'a self) -> &'a Vec<T> {
+        &self.records
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Records<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D>(d: D) -> std::result::Result<Records<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let embedded: Embedded<RecordsIntermediate<T>> = Embedded::deserialize(d)?;
+        Ok(Records {
+            records: embedded.embedded.records,
+        })
+    }
+}
+
+/// The HAL response format will embed resources within it. When it does
+/// this provides a wrapper to the `_embedded` key.
+///
+/// https://www.stellar.org/developers/horizon/reference/responses.html
+#[derive(Deserialize)]
+struct Embedded<T> {
+    #[serde(rename = "_embedded")] embedded: T,
+}
+
+/// If the embedded resource is a set of records, this can provide that data back in
+/// a generic way.
+#[derive(Deserialize)]
+struct RecordsIntermediate<T> {
+    records: Vec<T>,
+}
+
+#[cfg(test)]
+mod records_test {
+    use super::*;
+    use serde_json;
+
+    #[derive(Deserialize)]
+    struct Foo {
+        foo: String,
+    }
+
+    #[test]
+    fn it_parses_out_a_embedded_records_string() {
+        let json = r#"
+        {
+            "_embedded": {
+                "records": [
+                    { "foo": "bar" }
+                ]
+            }
+        }"#;
+        let records: Records<Foo> = serde_json::from_str(&json).unwrap();
+        assert_eq!(records.records().first().unwrap().foo, "bar");
+    }
 }


### PR DESCRIPTION
This implements the all assets endpoint which can be found documented
here:
https://www.stellar.org/developers/horizon/reference/endpoints/assets-all.html

In order to make this one work a deserializable `Records<T>` struct
needed to be constructed. This generally works but is lacking support
for parsing out the cursors. This has created the issue #42.