### PR TITLE
Implement cursor links for records

### DIFF
--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -46,6 +46,28 @@ use http::{Request, Uri};
 /// # assert_eq!(records.records()[0].issuer(), issuer);
 /// ```
 ///
+/// #### Cursor
+///
+/// Starts the page of results at a given cursor
+///
+/// ```
+/// # use stellar_client::sync::Client;
+/// # use stellar_client::endpoint::AllAssets;
+/// #
+/// let client      = Client::horizon_test().unwrap();
+/// #
+/// # // grab first page and extract cursor
+/// # let endpoint      = AllAssets::default().limit(1);
+/// # let first_page    = client.request(endpoint).unwrap();
+/// # let cursor        = first_page.next_cursor();
+/// #
+/// let endpoint    = AllAssets::default().cursor(cursor);
+/// let records     = client.request(endpoint).unwrap();
+/// #
+/// # assert!(records.records().len() > 0);
+/// # assert_ne!(records.next_cursor(), cursor);
+/// ```
+///
 /// #### Order
 ///
 /// Fetches all records in a set order, either ascending or descending.

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -1,12 +1,13 @@
 //! This module contains the various end point definitions for stellar's horizon
 //! API server.
 use error::Result;
-use std;
-use serde::de::{Deserialize, DeserializeOwned, Deserializer};
+use serde::de::DeserializeOwned;
 use http;
 
 mod account;
 mod asset;
+mod records;
+pub use self::records::Records;
 pub use self::account::AccountDetails;
 pub use self::asset::AllAssets;
 
@@ -36,80 +37,5 @@ impl Order {
             Order::Asc => "asc".to_string(),
             Order::Desc => "desc".to_string(),
         }
-    }
-}
-
-/// A struct that represents a set of records returned from the horizon api.
-#[derive(Debug)]
-pub struct Records<T>
-where
-    T: DeserializeOwned,
-{
-    records: Vec<T>,
-}
-
-impl<T> Records<T>
-where
-    T: DeserializeOwned,
-{
-    /// Returns a slice of the embedded records.
-    pub fn records<'a>(&'a self) -> &'a Vec<T> {
-        &self.records
-    }
-}
-
-impl<'de, T> Deserialize<'de> for Records<T>
-where
-    T: DeserializeOwned,
-{
-    fn deserialize<D>(d: D) -> std::result::Result<Records<T>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let embedded: Embedded<RecordsIntermediate<T>> = Embedded::deserialize(d)?;
-        Ok(Records {
-            records: embedded.embedded.records,
-        })
-    }
-}
-
-/// The HAL response format will embed resources within it. When it does
-/// this provides a wrapper to the `_embedded` key.
-///
-/// https://www.stellar.org/developers/horizon/reference/responses.html
-#[derive(Deserialize)]
-struct Embedded<T> {
-    #[serde(rename = "_embedded")] embedded: T,
-}
-
-/// If the embedded resource is a set of records, this can provide that data back in
-/// a generic way.
-#[derive(Deserialize)]
-struct RecordsIntermediate<T> {
-    records: Vec<T>,
-}
-
-#[cfg(test)]
-mod records_test {
-    use super::*;
-    use serde_json;
-
-    #[derive(Deserialize)]
-    struct Foo {
-        foo: String,
-    }
-
-    #[test]
-    fn it_parses_out_a_embedded_records_string() {
-        let json = r#"
-        {
-            "_embedded": {
-                "records": [
-                    { "foo": "bar" }
-                ]
-            }
-        }"#;
-        let records: Records<Foo> = serde_json::from_str(&json).unwrap();
-        assert_eq!(records.records().first().unwrap().foo, "bar");
     }
 }

--- a/client/src/endpoint/records.rs
+++ b/client/src/endpoint/records.rs
@@ -1,0 +1,140 @@
+use http;
+use serde::de::{Deserialize, DeserializeOwned, Deserializer};
+use std;
+
+/// A struct that represents a set of records returned from the horizon api.
+///
+/// Use this struct when querying an end point that returns an index route with
+/// embedded resources. There will also be a links object in the returned value
+/// that will provide access to the cursor to paginate.
+#[derive(Debug)]
+pub struct Records<T>
+where
+    T: DeserializeOwned,
+{
+    records: Vec<T>,
+    next: String,
+    prev: String,
+}
+
+impl<T> Records<T>
+where
+    T: DeserializeOwned,
+{
+    /// Returns a slice of the embedded records.
+    pub fn records<'a>(&'a self) -> &'a Vec<T> {
+        &self.records
+    }
+
+    /// Returns the pagination cursor for the next page
+    pub fn next_cursor<'a>(&'a self) -> &'a str {
+        &self.next
+    }
+
+    /// Returns the pagination cursor for the previous page
+    pub fn prev_cursor<'a>(&'a self) -> &'a str {
+        &self.prev
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Records<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D>(d: D) -> std::result::Result<Records<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let embedded: Embedded<RecordsIntermediate<T>> = Embedded::deserialize(d)?;
+        Ok(Records {
+            records: embedded.embedded.records,
+            next: embedded.links.next.cursor(),
+            prev: embedded.links.prev.cursor(),
+        })
+    }
+}
+
+/// The HAL response format will embed resources within it. When it does
+/// this provides a wrapper to the `_embedded` key.
+///
+/// https://www.stellar.org/developers/horizon/reference/responses.html
+#[derive(Deserialize)]
+struct Embedded<T> {
+    #[serde(rename = "_embedded")] embedded: T,
+    #[serde(rename = "_links")] links: Links,
+}
+
+/// If the embedded resource is a set of records, this can provide that data back in
+/// a generic way.
+#[derive(Deserialize)]
+struct RecordsIntermediate<T> {
+    records: Vec<T>,
+}
+
+#[derive(Deserialize)]
+struct Links {
+    next: Href,
+    prev: Href,
+}
+
+#[derive(Deserialize)]
+struct Href {
+    href: String,
+}
+
+impl Href {
+    fn cursor(&self) -> String {
+        // Any error should just result in an empty string cursor
+        if let Ok(uri) = self.href.parse::<http::Uri>() {
+            if let Some(queries) = uri.query() {
+                if let Some(query) = queries.split("&").find(|q| q.starts_with("cursor=")) {
+                    return query.replacen("cursor=", "", 1);
+                }
+            }
+        }
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod records_test {
+    use super::*;
+    use serde_json;
+
+    #[derive(Deserialize)]
+    struct Foo {
+        foo: String,
+    }
+
+    #[test]
+    fn it_parses_out_a_embedded_records_string() {
+        let json = r#"
+        {
+            "_links": {
+                "next": {
+                    "href": "/assets?order=asc&limit=10&cursor=NEXT_CURSOR"
+                },
+                "prev": {
+                    "href": "/assets?order=asc&limit=10&cursor=PREV_CURSOR"
+                }
+            },
+            "_embedded": {
+                "records": [
+                    { "foo": "bar" }
+                ]
+            }
+        }"#;
+        let records: Records<Foo> = serde_json::from_str(&json).unwrap();
+        assert_eq!(records.records().first().unwrap().foo, "bar");
+        assert_eq!(records.next_cursor(), "NEXT_CURSOR");
+        assert_eq!(records.prev_cursor(), "PREV_CURSOR");
+    }
+
+    #[test]
+    fn it_parses_the_cursor_out_of_an_href() {
+        let href = Href {
+            href: "/assets?order=asc\u{0026}limit=10\u{0026}cursor=NEXT_CURSOR".to_string(),
+        };
+        assert_eq!(href.cursor(), "NEXT_CURSOR");
+    }
+}


### PR DESCRIPTION
When multiple records are returned there are links embedded in them.
These links provide pagination cursors to the next and previous page.
We now parse these values out of the uris and provide them in order to
page to the next end point.