### PR TITLE
Implement a specific body type

### DIFF
--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -1,7 +1,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Account;
-use super::EndPoint;
+use super::{Body, EndPoint};
 use http::{Request, Uri};
 
 /// An endpoint that accesses a single accounts details.
@@ -20,11 +20,10 @@ impl AccountDetails {
 
 impl EndPoint for AccountDetails {
     type Response = Account;
-    type RequestBody = ();
 
-    fn into_request(self, host: &str) -> Result<Request<()>> {
+    fn into_request(self, host: &str) -> Result<Request<Body>> {
         let uri = Uri::from_str(&format!("{}/accounts/{}", host, self.id))?;
-        let request = Request::get(uri).body(())?;
+        let request = Request::get(uri).body(Body::None)?;
         Ok(request)
     }
 }

--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -1,7 +1,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Asset;
-use super::{EndPoint, Order, Records};
+use super::{Body, EndPoint, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all assets end point for the stellar horizon server. The endpoint
@@ -147,9 +147,8 @@ impl AllAssets {
 
 impl EndPoint for AllAssets {
     type Response = Records<Asset>;
-    type RequestBody = ();
 
-    fn into_request(self, host: &str) -> Result<Request<()>> {
+    fn into_request(self, host: &str) -> Result<Request<Body>> {
         let mut uri = format!("{}/assets", host);
 
         if self.has_query() {
@@ -176,7 +175,7 @@ impl EndPoint for AllAssets {
         }
 
         let uri = Uri::from_str(&uri)?;
-        let request = Request::get(uri).body(())?;
+        let request = Request::get(uri).body(Body::None)?;
         Ok(request)
     }
 }

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -11,15 +11,21 @@ pub use self::records::Records;
 pub use self::account::AccountDetails;
 pub use self::asset::AllAssets;
 
+/// Represents the body of a request to an EndPoint.
+#[derive(Debug)]
+pub enum Body {
+    /// Declares that the endpoint does not have a body.
+    None,
+}
+
 /// Declares the definition of a stellar endpoint and the return type.
 pub trait EndPoint {
     /// The deserializable type that is expected to come back from the stellar server.
     type Response: DeserializeOwned;
     /// The request body to be sent to stellar. Generally this is just a `()` unit.
-    type RequestBody;
 
     /// Converts the implementing struct into an http request.
-    fn into_request(self, host: &str) -> Result<http::Request<Self::RequestBody>>;
+    fn into_request(self, host: &str) -> Result<http::Request<Body>>;
 }
 
 /// The order to return results in.


### PR DESCRIPTION
So that we can be a little more specific in how an endpoint works, the
trait for an endpoint must now produce a request with a body of type
`Body`. This is an enum that can capture the idea of `None` but also
potentially capture the idea that there is a body in the future.
Currently, the only end point are `GET` endpoints so the body doesn't
matter but this removes the arbitrary generic typing we had around it.