### PR TITLE
Fix the warnings from `cargo doc`

### DIFF
--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -8,7 +8,7 @@ use http::{Request, Uri};
 /// Represents the all assets end point for the stellar horizon server. The endpoint
 /// will return all assets filtered by a myriad of different query params.
 ///
-/// https://www.stellar.org/developers/horizon/reference/endpoints/assets-all.html
+/// <https://www.stellar.org/developers/horizon/reference/endpoints/assets-all.html>
 ///
 /// ## Example
 ///

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -20,11 +20,11 @@ pub enum Error {
     /// this type does not map down well and currently is just wrapped
     /// generically. See the inner description for details.
     ///
-    /// https://github.com/hyperium/http/issues/188
+    /// <https://github.com/hyperium/http/issues/188>
     Http(http::Error),
     /// An error occurred while parsing the json
     ///
-    /// https://docs.serde.rs/serde_json/error/struct.Error.html
+    /// <https://docs.serde.rs/serde_json/error/struct.Error.html>
     ParseError(serde_json::error::Error),
     /// Catch-all for reqwest error handling
     Reqwest(reqwest::Error),

--- a/client/src/stellar_error.rs
+++ b/client/src/stellar_error.rs
@@ -3,10 +3,8 @@ use serde::{Deserialize, Deserializer};
 use std::fmt;
 
 /// A resource for the stellar horizon API specific error codes.
-/// These errors adhere to the Problem Details Standard
-/// https://tools.ietf.org/html/draft-ietf-appsawg-http-problem-00
-/// and a list of possible erros can be found here
-/// https://www.stellar.org/developers/horizon/reference/errors.html
+/// These errors adhere to the [Problem Details Standard](https://tools.ietf.org/html/draft-ietf-appsawg-http-problem-00)
+/// and a list of possible erros can be found [on the Stellar website](https://www.stellar.org/developers/horizon/reference/errors.html)
 #[derive(Debug, Deserialize)]
 pub struct StellarError {
     // type is a protected word

--- a/resources/src/account.rs
+++ b/resources/src/account.rs
@@ -2,7 +2,8 @@ use deserialize;
 
 /// In the Stellar network, users interact using accounts which can be controlled by a
 /// corresponding keypair that can authorize transactions.
-/// https://www.stellar.org/developers/horizon/reference/resources/account.html
+///
+/// <https://www.stellar.org/developers/horizon/reference/resources/account.html>
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Account {
     id: String,

--- a/resources/src/amount.rs
+++ b/resources/src/amount.rs
@@ -4,11 +4,12 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de;
 use std::str::FromStr;
 
-/// Amounts are used in several resources in the stellar ecosystem.  There
+/// Amounts are used in several resources in the stellar ecosystem. There
 /// are a lot of conversions that must take place to display amounts to users
-/// in a way that makes sense to both users and the horizon API.  That logic is contained
-/// in this module
-/// https://www.stellar.org/developers/guides/concepts/assets.html#amount-precision-and-representation
+/// in a way that makes sense to both users and the horizon API. That logic is contained
+/// in this module.
+///
+/// <https://www.stellar.org/developers/guides/concepts/assets.html#amount-precision-and-representation>
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub struct Amount(i64);
 

--- a/resources/src/asset.rs
+++ b/resources/src/asset.rs
@@ -4,7 +4,8 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 /// Assets are the units that are traded on the Stellar Network.
 /// An asset consists of an type, code, and issuer.
 /// Any asset can be traded for any other asset.
-/// https://www.stellar.org/developers/horizon/reference/resources/asset.html
+///
+/// <https://www.stellar.org/developers/horizon/reference/resources/asset.html>
 
 /// An identifer is the type, code, and issuer.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -220,7 +221,8 @@ impl Flag {
 /// Assets are the units that are traded on the Stellar Network.
 /// An asset consists of an type, code, and issuer.
 /// Any asset can be traded for any other asset.
-/// https://www.stellar.org/developers/horizon/reference/resources/asset.html
+///
+/// <https://www.stellar.org/developers/horizon/reference/resources/asset.html>
 #[derive(Debug)]
 pub struct Asset {
     asset_identifier: AssetIdentifier,
@@ -305,9 +307,9 @@ impl Asset {
 
     /// The number of units of credit issued for this asset.
     /// This number is scaled by 10 million to display the number if the format a
-    /// user would expect it in
-    /// https://www.stellar.org/developers/guides/concepts/assets.html
-    /// Returns a signed 64-bit integer.
+    /// user would expect it in.
+    ///
+    /// <https://www.stellar.org/developers/guides/concepts/assets.html#amount-precision-and-representation>
     pub fn amount(&self) -> Amount {
         self.amount
     }

--- a/resources/src/orderbook.rs
+++ b/resources/src/orderbook.rs
@@ -4,7 +4,8 @@ use asset::AssetIdentifier;
 /// Order books keep records of all offers to sell (asks)
 /// and offer to buy (bids) for a particular pair of assets.
 /// The asset pairs are refered to as a base and counter.
-/// https://www.stellar.org/developers/horizon/reference/resources/orderbook.html
+///
+/// <https://www.stellar.org/developers/horizon/reference/resources/orderbook.html>
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Orderbook {
     bids: Vec<OfferSummary>,

--- a/resources/src/trade.rs
+++ b/resources/src/trade.rs
@@ -6,7 +6,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 /// A trade represents an offer that was fulfilled between two assets and accounts.
 ///
-/// https://www.stellar.org/developers/horizon/reference/resources/trade.html
+/// <https://www.stellar.org/developers/horizon/reference/resources/trade.html>
 #[derive(Debug)]
 pub struct Trade {
     id: String,


### PR DESCRIPTION
There are warnings in the rendering differences when running `cargo
doc`. This is because rust is switching from `hoedown` to `pulldown` as
a rendering client. The changes are minor but auto-links are no longer
correctly supported. If you want to put a link you need to wrap it with
`<` and `>` or put it in a standard markdown link: `[text](link)`.

Another minor difference that I added was putting an extra space above
raw links to separate them from the descriptive text a bit. I also
wrapped one of the links into text so that it reads more intuitively.

For testing this, you should be able to run `cargo doc` and see no more
warnings on this repo.