### PR TITLE
Reduce test threads on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ before_script:
 script:
   - cargo fmt --all -- --write-mode=diff
   - cargo build
-  - cargo test
+  - cargo test -- --test-threads=1
 rust:
   - stable


### PR DESCRIPTION
It's possible that travis is killing our process while it's running.
This change will reduce the number of threads that run the specs to a
single thread which may give it more CPU power and continue executing.