### PR TITLE
Single ledger details endpoint

### DIFF
--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -126,6 +126,49 @@ impl EndPoint for All {
     }
 }
 
+/// Represents the ledger details endpoint for the stellar horizon server. The endpoint
+/// will return a single ledger's details.
+///
+/// https://www.stellar.org/developers/horizon/reference/endpoints/ledgers-single.html
+///
+/// ## Example
+/// ```
+/// use stellar_client::sync::Client;
+/// use stellar_client::endpoint::ledger;
+///
+/// let client      = Client::horizon_test().unwrap();
+/// let endpoint    = ledger::Details::new(12345);
+/// let record      = client.request(endpoint).unwrap();
+/// #
+/// # assert!(record.sequence() == 12345); //
+/// ```
+#[derive(Debug, Default)]
+pub struct Details {
+    sequence: u32,
+}
+
+impl Details {
+    /// Returns a new endpoint for ledger details. Hand this to the client in order to request
+    /// details about a ledger.
+    ///
+    /// In Stellar, the sequence number is the equivalent of Bitcoin's block height. Thus, by
+    /// specifying a sequence number of 12345, we are specifying the 12345th ledger in the
+    /// Stellar ledger chain (Stellar's blockchain is called a ledger chain).
+    pub fn new(sequence: u32) -> Self {
+        Self { sequence }
+    }
+}
+
+impl EndPoint for Details {
+    type Response = Ledger;
+
+    fn into_request(self, host: &str) -> Result<Request<Body>> {
+        let uri = Uri::from_str(&format!("{}/ledgers/{}", host, self.sequence))?;
+        let request = Request::get(uri).body(Body::None)?;
+        Ok(request)
+    }
+}
+
 #[cfg(test)]
 mod all_ledgers_tests {
     use super::*;
@@ -150,5 +193,15 @@ mod all_ledgers_tests {
             req.uri().query(),
             Some("order=desc&cursor=CURSOR&limit=123")
         );
+    }
+
+    #[test]
+    fn it_can_make_a_ledger_details_uri() {
+        let details = Details::new(12345);
+        let request = details
+            .into_request("https://horizon-testnet.stellar.org")
+            .unwrap();
+        assert_eq!(request.uri().host().unwrap(), "horizon-testnet.stellar.org");
+        assert_eq!(request.uri().path(), "/ledgers/12345");
     }
 }


### PR DESCRIPTION
Modeled off of #69. This simple endpoint only requires one param, the sequence. It is included under the ledgers endpoint module (_is that correct rust lingo???_) creating the desired logical method syntax for the ledgers endpoint:

```
ledgers::Details
ledgers::All
```

Closes #59 