### PR TITLE
Ran cargo fmt

### DIFF
--- a/client/src/endpoint/records.rs
+++ b/client/src/endpoint/records.rs
@@ -60,8 +60,10 @@ where
 /// https://www.stellar.org/developers/horizon/reference/responses.html
 #[derive(Deserialize)]
 struct Embedded<T> {
-    #[serde(rename = "_embedded")] embedded: T,
-    #[serde(rename = "_links")] links: Links,
+    #[serde(rename = "_embedded")]
+    embedded: T,
+    #[serde(rename = "_links")]
+    links: Links,
 }
 
 /// If the embedded resource is a set of records, this can provide that data back in

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -28,7 +28,8 @@ pub enum Error {
     ParseError(serde_json::error::Error),
     /// Catch-all for reqwest error handling
     Reqwest(reqwest::Error),
-    #[doc(hidden)] __Nonexhaustive,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// A result including client specific errors.

--- a/client/src/stellar_error.rs
+++ b/client/src/stellar_error.rs
@@ -8,7 +8,8 @@ use std::fmt;
 #[derive(Debug, Deserialize)]
 pub struct StellarError {
     // type is a protected word
-    #[serde(rename = "type")] error_type: ErrorType,
+    #[serde(rename = "type")]
+    error_type: ErrorType,
     title: String,
     status: u16,
     detail: String,

--- a/resources/src/account.rs
+++ b/resources/src/account.rs
@@ -8,7 +8,8 @@ use deserialize;
 pub struct Account {
     id: String,
     account_id: String,
-    #[serde(deserialize_with = "deserialize::from_str")] sequence: u64,
+    #[serde(deserialize_with = "deserialize::from_str")]
+    sequence: u64,
     subentry_count: u64,
 }
 

--- a/resources/src/asset.rs
+++ b/resources/src/asset.rs
@@ -29,8 +29,10 @@ pub struct AssetId {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IntermediateAssetIdentifier {
     asset_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")] asset_code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")] asset_issuer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    asset_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    asset_issuer: Option<String>,
 }
 
 impl<'de> Deserialize<'de> for AssetIdentifier {
@@ -234,8 +236,10 @@ pub struct Asset {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IntermediateAsset {
     asset_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")] asset_code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")] asset_issuer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    asset_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    asset_issuer: Option<String>,
     amount: Amount,
     num_accounts: u32,
     flags: Flag,

--- a/resources/src/effect/mod.rs
+++ b/resources/src/effect/mod.rs
@@ -217,7 +217,8 @@ impl Effect {
 struct Intermediate<'a> {
     id: String,
     paging_token: String,
-    #[serde(rename = "type")] kind: &'a str,
+    #[serde(rename = "type")]
+    kind: &'a str,
     account: Option<String>,
     starting_balance: Option<Amount>,
     amount: Option<Amount>,

--- a/resources/src/offer.rs
+++ b/resources/src/offer.rs
@@ -4,8 +4,10 @@ use asset::AssetIdentifier;
 /// The ratio between the asking and selling price
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Copy, Clone)]
 pub struct PriceRatio {
-    #[serde(rename = "n")] numerator: u64,
-    #[serde(rename = "d")] denominator: u64,
+    #[serde(rename = "n")]
+    numerator: u64,
+    #[serde(rename = "d")]
+    denominator: u64,
 }
 
 impl PriceRatio {
@@ -32,7 +34,8 @@ impl PriceRatio {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OfferSummary {
     amount: Amount,
-    #[serde(rename = "price_r")] price_ratio: PriceRatio,
+    #[serde(rename = "price_r")]
+    price_ratio: PriceRatio,
     price: Amount,
 }
 
@@ -80,7 +83,8 @@ pub struct Offer {
     selling: AssetIdentifier,
     buying: AssetIdentifier,
     amount: Amount,
-    #[serde(rename = "price_r")] price_ratio: PriceRatio,
+    #[serde(rename = "price_r")]
+    price_ratio: PriceRatio,
     price: Amount,
 }
 

--- a/resources/src/operation/create_passive_offer.rs
+++ b/resources/src/operation/create_passive_offer.rs
@@ -11,7 +11,8 @@ pub struct CreatePassiveOffer {
     selling: AssetIdentifier,
     buying: AssetIdentifier,
     amount: Amount,
-    #[serde(rename = "price_r")] price_ratio: PriceRatio,
+    #[serde(rename = "price_r")]
+    price_ratio: PriceRatio,
     price: Amount,
 }
 

--- a/resources/src/operation/manage_offer.rs
+++ b/resources/src/operation/manage_offer.rs
@@ -10,7 +10,8 @@ pub struct ManageOffer {
     selling: AssetIdentifier,
     buying: AssetIdentifier,
     amount: Amount,
-    #[serde(rename = "price_r")] price_ratio: PriceRatio,
+    #[serde(rename = "price_r")]
+    price_ratio: PriceRatio,
     price: Amount,
 }
 

--- a/resources/src/operation/mod.rs
+++ b/resources/src/operation/mod.rs
@@ -211,7 +211,8 @@ impl Operation {
 struct Intermediate<'a> {
     id: i64,
     paging_token: String,
-    #[serde(rename = "type")] kind: &'a str,
+    #[serde(rename = "type")]
+    kind: &'a str,
     account: Option<String>,
     funder: Option<String>,
     starting_balance: Option<Amount>,
@@ -233,7 +234,8 @@ struct Intermediate<'a> {
     selling_asset_code: Option<String>,
     selling_asset_issuer: Option<String>,
     offer_id: Option<i64>,
-    #[serde(rename = "price_r")] price_ratio: Option<PriceRatio>,
+    #[serde(rename = "price_r")]
+    price_ratio: Option<PriceRatio>,
     price: Option<Amount>,
     signer_key: Option<String>,
     signer_weight: Option<u8>,

--- a/resources/src/trade.rs
+++ b/resources/src/trade.rs
@@ -168,13 +168,17 @@ struct TradeRepresentation {
     base_account: String,
     base_amount: Amount,
     base_asset_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")] base_asset_code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")] base_asset_issuer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_asset_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_asset_issuer: Option<String>,
     counter_account: String,
     counter_amount: Amount,
     counter_asset_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")] counter_asset_code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")] counter_asset_issuer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    counter_asset_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    counter_asset_issuer: Option<String>,
     base_is_seller: bool,
     price: Price,
 }

--- a/resources/src/transaction.rs
+++ b/resources/src/transaction.rs
@@ -14,7 +14,8 @@ pub struct Transaction {
     ledger: u32,
     created_at: DateTime<Utc>,
     source_account: String,
-    #[serde(deserialize_with = "deserialize::from_str")] source_account_sequence: u64,
+    #[serde(deserialize_with = "deserialize::from_str")]
+    source_account_sequence: u64,
     fee_paid: i64,
     operation_count: u32,
     envelope_xdr: String,


### PR DESCRIPTION
Since rust has released v1.25 the default cargo fmt settings have
changed (for the better). It looks like attribute annotations now end up
the second line. This resolves that.