### PR TITLE
Implement bad response parsing for client errors

### DIFF
--- a/client/fixtures/before_history_error.json
+++ b/client/fixtures/before_history_error.json
@@ -1,5 +1,5 @@
 {
-  "type": "before_history",
+  "type": "https://stellar.org/horizon-errors/before_history",
   "title": "Data Requested Is Before Recorded History",
   "status": 410,
   "detail": "This horizon instance is configured to only track a portion of the stellar network's latest history. This request is asking for results prior to the recorded history known to this horizon instance.",

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -6,6 +6,7 @@ use reqwest;
 use serde_json;
 use std::error::Error as StdError;
 use std::fmt;
+use super::StellarError;
 
 /// A set of errors for use in the client
 #[derive(Debug)]
@@ -15,7 +16,9 @@ pub enum Error {
     /// Was unable to resolve ssl configuration
     BadSSL,
     /// Placeholder for errors that come back from the client.
-    BadResponse,
+    BadResponse(StellarError),
+    /// Server error detected
+    ServerError,
     /// The response was from the http library and resulted in an error.
     /// this type does not map down well and currently is just wrapped
     /// generically. See the inner description for details.
@@ -43,7 +46,8 @@ impl StdError for Error {
             Error::Http(ref inner) => inner.description(),
             Error::Reqwest(ref inner) => inner.description(),
             Error::ParseError(ref inner) => inner.description(),
-            Error::BadResponse => "A non-successful response came back from the stellar server",
+            Error::BadResponse(ref inner) => inner.description(),
+            Error::ServerError => "An unknown error on the server has occurred",
             Error::__Nonexhaustive => unreachable!(),
         }
     }


### PR DESCRIPTION
If the request to stellar is incorrect we may get back a bad response.
This response has a defined type and we can parse it from that json type
into our known StellarErrors. Along the way I noticed that the "type"
field is actually a url and not a slug at all. I've corrected it.

I also renamed the `ErrorType` field into `Kind` and began using the
`FromStr` trait to parse the `Kind` instead of a custom method. It might
be useful to parse this into a separate field as well to return the URL
to visit in the future as reference.

fixes #27 