### PR TITLE
Add data resource and account data endpoint

### DIFF
--- a/resources/Cargo.toml
+++ b/resources/Cargo.toml
@@ -8,3 +8,4 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde", "rustc-serialize"] }
+base64 = "0.9"

--- a/resources/src/account.rs
+++ b/resources/src/account.rs
@@ -1,4 +1,6 @@
 use deserialize;
+use std::collections::HashMap;
+use base64string::Base64String;
 
 /// In the Stellar network, users interact using accounts which can be controlled by a
 /// corresponding keypair that can authorize transactions.
@@ -11,6 +13,7 @@ pub struct Account {
     #[serde(deserialize_with = "deserialize::from_str")]
     sequence: u64,
     subentry_count: u64,
+    data: HashMap<String, Base64String>,
 }
 
 impl Account {
@@ -48,5 +51,10 @@ impl Account {
     /// 0.5 to determine the minimum required balance.
     pub fn subentry_count(&self) -> u64 {
         self.subentry_count
+    }
+
+    /// A key/value store of data attached to this account.
+    pub fn data(&self) -> &HashMap<String, Base64String> {
+        &self.data
     }
 }

--- a/resources/src/base64string.rs
+++ b/resources/src/base64string.rs
@@ -1,0 +1,107 @@
+use std::fmt;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use base64::{decode, encode};
+
+/// Base64 encoded Strings are used in several resources in the stellar ecosystem. There
+/// are encoding and decoding conversions that must take place to display data to users
+/// in a way that makes sense to both users and the horizon API. That logic is contained
+/// in this module.
+///
+/// An example where this is used:
+/// <https://www.stellar.org/developers/horizon/reference/resources/data.html#attributes>
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct Base64String(pub String);
+
+impl Base64String {
+    /// Create a base64string newtype
+    pub fn new(thing: String) -> Base64String {
+        Base64String(thing)
+    }
+}
+
+#[cfg(test)]
+mod base64string_tests {
+    use super::*;
+    #[test]
+    fn it_creates_a_new_base64string() {
+        assert_eq!(
+            Base64String::new(String::from("abc123")),
+            Base64String(String::from("abc123"))
+        );
+    }
+}
+
+/// Base64Strings are stored as decoded Strings so we can simply
+/// return the raw string to display to the user.
+impl fmt::Display for Base64String {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0.to_string())
+    }
+}
+
+#[cfg(test)]
+mod display_amount_tests {
+    use super::*;
+    #[test]
+    fn it_displays_as_a_string() {
+        assert_eq!(
+            format!("{}", Base64String(String::from("abc123"))),
+            "abc123"
+        );
+    }
+}
+
+/// Converts internally stored data value of a string into a base64 encoded value
+/// and returns a serialized string of the result.
+impl Serialize for Base64String {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let formatted_string = format!("{}", self);
+        let encoded_string = encode(&formatted_string);
+        serializer.serialize_str(&encoded_string)
+    }
+}
+
+#[cfg(test)]
+mod serialize_amount_tests {
+    use super::*;
+    use serde_json;
+    #[test]
+    fn it_displays_data_as_base64_encoded() {
+        let base64string = Base64String(String::from("Pizza"));
+        assert_eq!(
+            serde_json::to_string(&base64string).unwrap(),
+            "\"UGl6emE=\""
+        );
+    }
+}
+
+/// The stellar value fields of account key/value pairs are represented as
+/// base64 encoded strings in the horizon api. This function converts the
+/// base64 encoded string into regular utf8.
+impl<'de> Deserialize<'de> for Base64String {
+    fn deserialize<D>(d: D) -> Result<Base64String, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+        let decoded_vec = decode(&s).unwrap();
+        let decoded_string = String::from_utf8(decoded_vec).unwrap();
+
+        Ok(Base64String::new(decoded_string))
+    }
+}
+
+#[cfg(test)]
+mod deserialize_base64string_tests {
+    use serde_json;
+    use super::*;
+
+    #[test]
+    fn it_decodes_base64() {
+        let data: Base64String = serde_json::from_str("\"UGl6emE=\"").unwrap();
+        assert_eq!(data, Base64String(String::from("Pizza")));
+    }
+}

--- a/resources/src/datum.rs
+++ b/resources/src/datum.rs
@@ -1,0 +1,18 @@
+use base64string::Base64String;
+
+/// In the Stellar network, key/value pairs can be attached to accounts.
+/// These key/value pairs can be useful for associating data with an account
+/// for various reasons. Datum represents the value of a single key/value pair.
+///
+/// <https://www.stellar.org/developers/horizon/reference/resources/data.html>
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Datum {
+    value: Base64String,
+}
+
+impl Datum {
+    /// The value of a single key/value pair tied to a single account.
+    pub fn value<'a>(&'a self) -> &'a str {
+        &self.value.0
+    }
+}

--- a/resources/src/lib.rs
+++ b/resources/src/lib.rs
@@ -2,6 +2,7 @@
 //! Defines the basic resources of stellar's horizon end points and
 //! implements their serialization.
 
+extern crate base64;
 extern crate chrono;
 extern crate serde;
 #[macro_use]
@@ -11,12 +12,14 @@ extern crate serde_json;
 mod account;
 mod amount;
 mod asset;
+mod base64string;
+mod datum;
 mod deserialize;
 /// An effect represents specific changes that occur in the ledger resulting from operations.
 pub mod effect;
 mod ledger;
 mod offer;
-/// An ooperation is an individual command that mutates the ledger.
+/// An operation is an individual command that mutates the ledger.
 pub mod operation;
 mod orderbook;
 mod payment_path;
@@ -31,6 +34,7 @@ mod transaction;
 pub use account::Account;
 pub use amount::Amount;
 pub use asset::{Asset, AssetIdentifier};
+pub use datum::Datum;
 pub use effect::Effect;
 pub use ledger::Ledger;
 pub use offer::Offer;


### PR DESCRIPTION
Take more as a first draft.

As noted in #50 I was unsure if it is necessary to create a new data resource. Ultimately, data is stored on and associated with accounts in the Stellar Network. However, this endpoint does not return an account, or event the hash map of data for an account, it returns a single value for a key/value pair.

Also, calling the new method with two inputs felt a little weird. Thoughts on this?

Closes #50 