### PR TITLE
Make the cursor doctest fallible

### DIFF
--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -105,7 +105,7 @@ impl All {
     /// let client      = Client::horizon_test().unwrap();
     /// #
     /// # // grab first page and extract cursor
-    /// # let endpoint      = asset::All::default().limit(1);
+    /// # let endpoint      = asset::All::default();
     /// # let first_page    = client.request(endpoint).unwrap();
     /// # let cursor        = first_page.next_cursor();
     /// #

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -59,7 +59,7 @@ impl All {
     /// let client      = Client::horizon_test().unwrap();
     /// #
     /// # // grab first page and extract cursor
-    /// # let endpoint      = ledger::All::default().limit(1);
+    /// # let endpoint      = ledger::All::default();
     /// # let first_page    = client.request(endpoint).unwrap();
     /// # let cursor        = first_page.next_cursor();
     /// #


### PR DESCRIPTION
The current cursor tests were infallible since the limits between the
first page and second page were different. This meant that the next
cursor was always different. By using the same limit these tests can
actually fail if the cursor is not implemented.