### PR TITLE
Implement Iterator for Records

### DIFF
--- a/client/src/client/sync/iter.rs
+++ b/client/src/client/sync/iter.rs
@@ -1,0 +1,127 @@
+use endpoint::{Cursor, EndPoint, Records};
+use serde::de::DeserializeOwned;
+use super::Client;
+use error::Result;
+
+/// An iterator for records. Provides the ability to use the iterator
+/// in rust against records that are returned from the api.
+///
+/// # Examples
+///
+/// ```
+/// use stellar_client::{
+///     endpoint::asset,
+///     sync::{Client, Iter},
+/// };
+/// let client = Client::horizon_test().unwrap();
+/// let endpoint = asset::All::default().limit(3);
+/// let iter = Iter::new(&client, endpoint);
+/// assert_eq!(iter.take(10).count(), 10);
+/// ```
+#[derive(Debug)]
+pub struct Iter<'a, T, E>
+where
+    E: EndPoint<Response = Records<T>> + Clone + Cursor<T>,
+    T: DeserializeOwned + Clone,
+{
+    client: &'a Client,
+    endpoint: E,
+    records: Option<Records<T>>,
+    next: usize,
+    has_err: bool,
+}
+
+impl<'a, T, E> Iter<'a, T, E>
+where
+    E: EndPoint<Response = Records<T>> + Clone + Cursor<T>,
+    T: DeserializeOwned + Clone,
+{
+    /// Creates a new iterator for the client and endpoint.
+    pub fn new(client: &'a Client, endpoint: E) -> Self {
+        Iter {
+            client,
+            endpoint,
+            next: 0,
+            records: None,
+            has_err: false,
+        }
+    }
+
+    fn try_next_page(&mut self) -> Result<()> {
+        if self.has_cache() {
+            return Ok(());
+        }
+
+        self.next = 0;
+        let mut endpoint = self.endpoint.clone();
+        if let Some(ref records) = self.records {
+            endpoint = endpoint.cursor(records.next_cursor());
+        }
+        self.records = Some(self.client.request(endpoint)?);
+        Ok(())
+    }
+
+    fn has_cache(&self) -> bool {
+        if let Some(ref records) = self.records {
+            self.next < records.records().len()
+        } else {
+            false
+        }
+    }
+}
+
+impl<'a, T, E> Iterator for Iter<'a, T, E>
+where
+    E: EndPoint<Response = Records<T>> + Clone + Cursor<T>,
+    T: DeserializeOwned + Clone,
+{
+    type Item = Result<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.has_err {
+            return None;
+        }
+
+        match self.try_next_page() {
+            Ok(()) => {
+                if let Some(ref records) = self.records {
+                    if records.records().len() > 0 {
+                        let val = records.records()[self.next].clone();
+                        self.next += 1;
+                        return Some(Ok(val));
+                    }
+                }
+                None
+            }
+            Err(err) => {
+                self.has_err = true;
+                Some(Err(err))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod iterator_tests {
+    use super::*;
+    use endpoint::{account, asset};
+    use stellar_resources::Transaction;
+
+    #[test]
+    fn it_can_iterate_through_records() {
+        let client = Client::horizon_test().unwrap();
+        let endpoint = asset::All::default().limit(3);
+        let iter = Iter::new(&client, endpoint);
+        assert!(iter.take(10).count() > 3);
+    }
+
+    #[test]
+    fn it_returns_one_with_error_if_request_fails() {
+        let client = Client::horizon_test().unwrap();
+        let endpoint = account::Transactions::new("NOT AN ID");
+        let iter = Iter::new(&client, endpoint);
+        let all: Vec<Result<Transaction>> = iter.collect();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].is_err());
+    }
+}

--- a/client/src/client/sync/mod.rs
+++ b/client/src/client/sync/mod.rs
@@ -8,6 +8,10 @@ use super::{Host, HORIZON_TEST_URI, HORIZON_URI};
 use StellarError;
 use serde_json;
 
+mod iter;
+
+pub use self::iter::Iter;
+
 /// A client that can issue requests to a horizon api in a synchronous
 /// fashion, meaning that the functions will block until the response
 /// has been formed. The overall performance of this is slightly slower

--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -1,9 +1,8 @@
 //! Contains endpoints for accessing accounts and related information.
 use error::Result;
 use std::str::FromStr;
-use stellar_resources::Account;
-use stellar_resources::Transaction;
-use super::{Body, EndPoint, Order, Records};
+use stellar_resources::{Account, Transaction};
+use super::{Body, Cursor, EndPoint, Order, Records};
 use http::{Request, Uri};
 
 /// An endpoint that accesses a single accounts details.
@@ -45,7 +44,7 @@ mod details_tests {
     }
 }
 /// An endpoint that accesses the transactions for a specific account
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Transactions {
     id: String,
     cursor: Option<String>,
@@ -145,6 +144,12 @@ impl Transactions {
 
     fn has_query(&self) -> bool {
         self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
+    }
+}
+
+impl Cursor<Transaction> for Transactions {
+    fn cursor(self, cursor: &str) -> Self {
+        self.cursor(cursor)
     }
 }
 

--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Asset;
-use super::{Body, EndPoint, Order, Records};
+use super::{Body, Cursor, EndPoint, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all assets end point for the stellar horizon server. The endpoint
@@ -22,7 +22,7 @@ use http::{Request, Uri};
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct All {
     code: Option<String>,
     issuer: Option<String>,
@@ -94,6 +94,25 @@ impl All {
         self
     }
 
+    /// Sets the maximum number of records to return.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::sync::Client;
+    /// use stellar_client::endpoint::asset;
+    ///
+    /// let client      = Client::horizon_test().unwrap();
+    /// let endpoint    = asset::All::default().limit(3);
+    /// let records     = client.request(endpoint).unwrap();
+    /// #
+    /// # assert_eq!(records.records().len(), 3);
+    /// ```
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
     /// Starts the page of results at a given cursor
     ///
     /// ## Example
@@ -120,28 +139,15 @@ impl All {
         self
     }
 
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::sync::Client;
-    /// use stellar_client::endpoint::asset;
-    ///
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = asset::All::default().limit(3);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert_eq!(records.records().len(), 3);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
-        self
-    }
-
     fn has_query(&self) -> bool {
         self.code.is_some() || self.issuer.is_some() || self.order.is_some()
             || self.cursor.is_some() || self.limit.is_some()
+    }
+}
+
+impl Cursor<Asset> for All {
+    fn cursor(self, cursor: &str) -> Self {
+        self.cursor(cursor)
     }
 }
 

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -12,7 +12,7 @@ pub mod payment;
 pub mod transaction;
 mod records;
 
-pub use self::records::Records;
+pub use self::records::{Cursor, Records};
 
 /// Represents the body of a request to an EndPoint.
 #[derive(Debug)]
@@ -32,7 +32,7 @@ pub trait EndPoint {
 }
 
 /// The order to return results in.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Order {
     /// Order the results ascending
     Asc,

--- a/client/src/endpoint/records.rs
+++ b/client/src/endpoint/records.rs
@@ -1,6 +1,16 @@
 use http;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};
+use super::EndPoint;
 use std;
+
+/// Declares that this endpoint has a cursor and can have it set.
+pub trait Cursor<T>: EndPoint<Response = Records<T>>
+where
+    T: DeserializeOwned,
+{
+    /// Sets a cursor on the endpoint.
+    fn cursor(self, cursor: &str) -> Self;
+}
 
 /// A struct that represents a set of records returned from the horizon api.
 ///

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Transaction;
-use super::{Body, EndPoint, Order, Records};
+use super::{Body, Cursor, EndPoint, Order, Records};
 use http::{Request, Uri};
 pub use super::account::Transactions as ForAccount;
 
@@ -125,6 +125,12 @@ impl EndPoint for All {
         let uri = Uri::from_str(&uri)?;
         let request = Request::get(uri).body(Body::None)?;
         Ok(request)
+    }
+}
+
+impl Cursor<Transaction> for All {
+    fn cursor(self, cursor: &str) -> Self {
+        self.cursor(cursor)
     }
 }
 

--- a/resources/src/asset.rs
+++ b/resources/src/asset.rs
@@ -225,7 +225,7 @@ impl Flag {
 /// Any asset can be traded for any other asset.
 ///
 /// <https://www.stellar.org/developers/horizon/reference/resources/asset.html>
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Asset {
     asset_identifier: AssetIdentifier,
     amount: Amount,

--- a/resources/src/transaction.rs
+++ b/resources/src/transaction.rs
@@ -6,7 +6,7 @@ use deserialize;
 /// A transaction is a grouping of operations.
 ///
 /// To learn more about the concept of transactions in the Stellar network, take a look at the Stellar transactions concept guide.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Transaction {
     id: String,
     paging_token: String,


### PR DESCRIPTION
So, the actual Records struct can't really be an iterator across all
records due to it's lack of knowledge about the client and the endpoint
it's part of. But, we can create a record iter for use with the sync client!

This commit implements that type. It requires some traits to be
implemented by the resource and the endpoint for it to work correctly.
It needs to be able to clone the endpoint and the resource. Also, the
endpoint must have an associated type of a `Record`. This allows us to
paginate based on the endpoint, cache the returned records, then iterate
through them.

This immediately allows us to paginate across the entire set of records
associated with whatever endpoint we want. This _should_ be lazy based
on the way that rust iterators work themselves as they are lazy by
default.