### PR TITLE
Renames the trait EndPoint to IntoRequest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,13 @@ nursery: https://github.com/rust-lang-nursery/rustfmt
 Naming and conventions to improve the public interface should be followed and considered. We want
 sdk to be as easy to use as possible.
 
+When developing a trait please consider that traits are more like verbs than nouns. As such the
+convention has been to utilize words like `Clone` instead of `Cloneable` and `Write` instead of
+`Writer`. Sometimes a noun might make the right word but generally we should favor describing
+what it does rather than what it is.
+
+There is an open proposal for this on the rust-lang nursery:
+https://github.com/rust-lang-nursery/api-guidelines/issues/28
 
 ## Proposing changes
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ are fully documented and can be deserialized from the client.
 ## Client
 
 The client provides two interfaces. One is the synchronous client and the other is
-the asynchronous client. Both consume an EndPoint trait and will return the appropriate
+the asynchronous client. Both consume an IntoRequest trait and will return the appropriate
 response associated with the endpoint implementation. You should see the documentation
 associated with the code itself but below is a brief example
 

--- a/client/src/client/sync/iter.rs
+++ b/client/src/client/sync/iter.rs
@@ -1,4 +1,4 @@
-use endpoint::{Cursor, EndPoint, Records};
+use endpoint::{Cursor, IntoRequest, Records};
 use serde::de::DeserializeOwned;
 use super::Client;
 use error::Result;
@@ -21,7 +21,7 @@ use error::Result;
 #[derive(Debug)]
 pub struct Iter<'a, T, E>
 where
-    E: EndPoint<Response = Records<T>> + Clone + Cursor<T>,
+    E: IntoRequest<Response = Records<T>> + Clone + Cursor<T>,
     T: DeserializeOwned + Clone,
 {
     client: &'a Client,
@@ -33,7 +33,7 @@ where
 
 impl<'a, T, E> Iter<'a, T, E>
 where
-    E: EndPoint<Response = Records<T>> + Clone + Cursor<T>,
+    E: IntoRequest<Response = Records<T>> + Clone + Cursor<T>,
     T: DeserializeOwned + Clone,
 {
     /// Creates a new iterator for the client and endpoint.
@@ -72,7 +72,7 @@ where
 
 impl<'a, T, E> Iterator for Iter<'a, T, E>
 where
-    E: EndPoint<Response = Records<T>> + Clone + Cursor<T>,
+    E: IntoRequest<Response = Records<T>> + Clone + Cursor<T>,
     T: DeserializeOwned + Clone,
 {
     type Item = Result<T>;

--- a/client/src/client/sync/mod.rs
+++ b/client/src/client/sync/mod.rs
@@ -3,7 +3,7 @@
 use reqwest;
 use http::{self, Uri};
 use error::{Error, Result};
-use endpoint::EndPoint;
+use endpoint::IntoRequest;
 use super::{Host, HORIZON_TEST_URI, HORIZON_URI};
 use StellarError;
 use serde_json;
@@ -118,7 +118,7 @@ impl Client {
     /// ```
     pub fn request<E>(&self, endpoint: E) -> Result<E::Response>
     where
-        E: EndPoint,
+        E: IntoRequest,
     {
         let request = endpoint.into_request(&self.uri())?;
         let request = Self::http_to_reqwest(request);

--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::{Account, Datum, Transaction};
-use super::{Body, Cursor, EndPoint, Order, Records};
+use super::{Body, Cursor, IntoRequest, Order, Records};
 use http::{Request, Uri};
 
 /// An endpoint that accesses a single accounts details.
@@ -19,7 +19,7 @@ impl Details {
     }
 }
 
-impl EndPoint for Details {
+impl IntoRequest for Details {
     type Response = Account;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {
@@ -61,7 +61,7 @@ impl Data {
     }
 }
 
-impl EndPoint for Data {
+impl IntoRequest for Data {
     type Response = Datum;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {
@@ -204,7 +204,7 @@ impl Cursor<Transaction> for Transactions {
     }
 }
 
-impl EndPoint for Transactions {
+impl IntoRequest for Transactions {
     type Response = Records<Transaction>;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {

--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Asset;
-use super::{Body, Cursor, EndPoint, Order, Records};
+use super::{Body, Cursor, IntoRequest, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all assets end point for the stellar horizon server. The endpoint
@@ -151,7 +151,7 @@ impl Cursor<Asset> for All {
     }
 }
 
-impl EndPoint for All {
+impl IntoRequest for All {
     type Response = Records<Asset>;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {

--- a/client/src/endpoint/effect.rs
+++ b/client/src/endpoint/effect.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Effect;
-use super::{Body, EndPoint, Order, Records};
+use super::{Body, IntoRequest, Order, Records};
 use http::{Request, Uri};
 
 /// This endpoint represents all effects that have resulted from successful opreations in Stellar.
@@ -98,7 +98,7 @@ impl All {
     }
 }
 
-impl EndPoint for All {
+impl IntoRequest for All {
     type Response = Records<Effect>;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Ledger;
-use super::{Body, EndPoint, Order, Records};
+use super::{Body, IntoRequest, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all ledgers end point for the stellar horizon server. The endpoint
@@ -98,7 +98,7 @@ impl All {
     }
 }
 
-impl EndPoint for All {
+impl IntoRequest for All {
     type Response = Records<Ledger>;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {
@@ -159,7 +159,7 @@ impl Details {
     }
 }
 
-impl EndPoint for Details {
+impl IntoRequest for Details {
     type Response = Ledger;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -14,7 +14,7 @@ mod records;
 
 pub use self::records::{Cursor, Records};
 
-/// Represents the body of a request to an EndPoint.
+/// Represents the body of a request to an IntoRequest.
 #[derive(Debug)]
 pub enum Body {
     /// Declares that the endpoint does not have a body.
@@ -22,7 +22,7 @@ pub enum Body {
 }
 
 /// Declares the definition of a stellar endpoint and the return type.
-pub trait EndPoint {
+pub trait IntoRequest {
     /// The deserializable type that is expected to come back from the stellar server.
     type Response: DeserializeOwned;
     /// The request body to be sent to stellar. Generally this is just a `()` unit.

--- a/client/src/endpoint/payment.rs
+++ b/client/src/endpoint/payment.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Operation;
-use super::{Body, EndPoint, Order, Records};
+use super::{Body, IntoRequest, Order, Records};
 use http::{Request, Uri};
 
 /// This endpoint represents all payment operations that are part of validated transactions.
@@ -98,7 +98,7 @@ impl All {
     }
 }
 
-impl EndPoint for All {
+impl IntoRequest for All {
     type Response = Records<Operation>;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {

--- a/client/src/endpoint/records.rs
+++ b/client/src/endpoint/records.rs
@@ -1,10 +1,10 @@
 use http;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};
-use super::EndPoint;
+use super::IntoRequest;
 use std;
 
 /// Declares that this endpoint has a cursor and can have it set.
-pub trait Cursor<T>: EndPoint<Response = Records<T>>
+pub trait Cursor<T>: IntoRequest<Response = Records<T>>
 where
     T: DeserializeOwned,
 {

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Transaction;
-use super::{Body, Cursor, EndPoint, Order, Records};
+use super::{Body, Cursor, IntoRequest, Order, Records};
 use http::{Request, Uri};
 pub use super::account::Transactions as ForAccount;
 
@@ -101,7 +101,7 @@ impl All {
     }
 }
 
-impl EndPoint for All {
+impl IntoRequest for All {
     type Response = Records<Transaction>;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {
@@ -196,7 +196,7 @@ impl Details {
     }
 }
 
-impl EndPoint for Details {
+impl IntoRequest for Details {
     type Response = Transaction;
 
     fn into_request(self, host: &str) -> Result<Request<Body>> {


### PR DESCRIPTION
To follow along with what appear to be common naming conventions in rust
I'm proposing to rename the EndPoint trait to IntoRequest. This does not
change the module (I still like classifying it as endpoints at the
module lever) but I want to be explicit about what the trait does, not
what it's supposed to "be". Since the point of the trait is to consume
itself and produce a request, this trait name seems more appropriate.

see this issue in the rust-nursery:
https://github.com/rust-lang-nursery/api-guidelines/issues/28

warning: This is may be slightly controversial.