### PR TITLE
Major enhancements to cli

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,0 +1,34 @@
+use clap::ArgMatches;
+use stellar_client::{sync, endpoint::{account, Order}, error::Result, sync::Client};
+use super::utils;
+
+pub fn details<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
+    let id = matches.value_of("ID").expect("ID is required");
+    let endpoint = account::Details::new(id);
+    let account = client.request(endpoint)?;
+
+    println!("ID:       {}", account.id());
+    println!("Sequence: {}", account.sequence());
+
+    Ok(())
+}
+
+pub fn transactions<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
+    let id = matches.value_of("ID").expect("ID is required");
+    let endpoint = account::Transactions::new(id).order(Order::Desc);
+    let iter = sync::Iter::new(&client, endpoint);
+
+    for (i, result) in iter.enumerate() {
+        let txn = result?;
+
+        println!("ID:             {}", txn.id());
+        println!("source account: {}", txn.source_account());
+        println!("created at:     {}", txn.created_at());
+        println!("");
+
+        if (i + 1) % 10 == 0 && !utils::next_page() {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/cli/src/assets.rs
+++ b/cli/src/assets.rs
@@ -1,0 +1,39 @@
+use stellar_client::{endpoint::{asset, Order}, error::Result, sync::{self, Client}};
+use clap::ArgMatches;
+use super::utils;
+
+pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
+    let endpoint = {
+        let mut endpoint = asset::All::default().order(Order::Asc);
+        if let Some(code) = matches.value_of("code") {
+            endpoint = endpoint.asset_code(code)
+        }
+        if let Some(issuer) = matches.value_of("issuer") {
+            endpoint = endpoint.asset_issuer(issuer)
+        }
+        endpoint
+    };
+    let iter = sync::Iter::new(&client, endpoint);
+
+    for (i, result) in iter.enumerate() {
+        let asset = result?;
+        println!("Code:           {}", asset.code());
+        println!("Type:           {}", asset.asset_type());
+        println!("Issuer:         {}", asset.issuer());
+        println!("Amount:         {}", asset.amount());
+        println!("Num accounts:   {}", asset.num_accounts());
+        println!("Flags:");
+        if asset.is_auth_required() {
+            println!("  auth is required");
+        }
+        if asset.is_auth_revocable() {
+            println!("  auth is revocable");
+        }
+        println!("");
+
+        if (i + 1) % 10 == 0 && !utils::next_page() {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -1,0 +1,20 @@
+use stellar_client::{endpoint::{transaction, Order}, error::Result, sync::{self, Client}};
+use super::utils;
+
+pub fn all<'a>(client: Client) -> Result<()> {
+    let endpoint = transaction::All::default().order(Order::Desc);
+    let iter = sync::Iter::new(&client, endpoint);
+
+    for (i, result) in iter.enumerate() {
+        let txn = result?;
+        println!("ID:             {}", txn.id());
+        println!("source account: {}", txn.source_account());
+        println!("created at:     {}", txn.created_at());
+        println!("");
+
+        if (i + 1) % 10 == 0 && !utils::next_page() {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -23,7 +23,7 @@ pub use super::account::Transactions as ForAccount;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct All {
     cursor: Option<String>,
     order: Option<Order>,


### PR DESCRIPTION
Several things went into this change. Some was refactoring and some were
new enhancements.

*Added All Assets*

The first change was the most straight forward, the assets endpoint was
added. This end point features filtering via the command line args of
code and issuer.

*Switched to using the Iter*

The second change was the migration to using the iterator. This majorly
simplifies the code and eliminates the need for the recursion that was
there to begin with. I use the `enumerate` iterator to pair each line
with the index so that we can paginate.

*Functions return result types now*

Instead of duplicating the exception handling through out, instead we
just have each function return the client errors and handle it all at
the end.

*Choose the network!*

Another option that was added was the ability specify which network you
wished to join!

*Move the groups of functions to modules*

The file was feeling a little complex so I moved each group of commands
to their own module file. They were already modules so this was very
straightforward.