### PR TITLE
Adds the payments for transaction endpoint

### DIFF
--- a/client/src/endpoint/payment.rs
+++ b/client/src/endpoint/payment.rs
@@ -5,6 +5,8 @@ use stellar_resources::Operation;
 use super::{Body, IntoRequest, Order, Records};
 use http::{Request, Uri};
 
+pub use super::transaction::Payments as ForTransaction;
+
 /// This endpoint represents all payment operations that are part of validated transactions.
 /// The endpoint will return all payments and accepts query params for a cursor, order, and limit.
 ///

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -1,7 +1,7 @@
 //! Contains endpoints for transactions and related information.
 use error::Result;
 use std::str::FromStr;
-use stellar_resources::Transaction;
+use stellar_resources::{Operation, Transaction};
 use super::{Body, Cursor, IntoRequest, Order, Records};
 use http::{Request, Uri};
 pub use super::account::Transactions as ForAccount;
@@ -218,5 +218,188 @@ mod transaction_details_tests {
             .unwrap();
         assert_eq!(request.uri().host().unwrap(), "horizon-testnet.stellar.org");
         assert_eq!(request.uri().path(), "/transactions/123");
+    }
+}
+
+/// Returns the payments associated with a single transactions.
+///
+/// <https://www.stellar.org/developers/horizon/reference/endpoints/payments-for-transaction.html>
+///
+/// ## Example
+///
+/// ```
+/// use stellar_client::sync::Client;
+/// use stellar_client::endpoint::transaction;
+///
+/// let client   = Client::horizon_test().unwrap();
+/// # let transaction_ep   = transaction::All::default().limit(1);
+/// # let txns             = client.request(transaction_ep).unwrap();
+/// # let txn              = &txns.records()[0];
+/// # let hash             = txn.hash();
+/// let endpoint = transaction::Payments::new(hash);
+/// let payments = client.request(endpoint).unwrap();
+/// #
+/// # // Impossible to assert seeing as not all transactions have payments
+/// ```
+#[derive(Debug, Clone)]
+pub struct Payments {
+    hash: String,
+    cursor: Option<String>,
+    order: Option<Order>,
+    limit: Option<u32>,
+}
+
+impl Payments {
+    /// Creates a new struct representing a request to the payments endpoint
+    pub fn new(hash: &str) -> Payments {
+        Payments {
+            hash: hash.to_string(),
+            cursor: None,
+            order: None,
+            limit: None,
+        }
+    }
+
+    /// Starts the page of results at a given cursor
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::sync::Client;
+    /// use stellar_client::endpoint::transaction;
+    /// # use stellar_client::endpoint::Order;
+    ///
+    /// let client = Client::horizon_test().unwrap();
+    /// #
+    /// # let transaction_ep   = transaction::All::default().limit(1);
+    /// # let txns             = client.request(transaction_ep).unwrap();
+    /// # let txn              = &txns.records()[0];
+    /// # let hash             = txn.hash();
+    /// # let endpoint = transaction::Payments::new(hash);
+    /// # let prev_page = client.request(endpoint).unwrap();
+    /// # let cursor = prev_page.next_cursor();
+    /// #
+    /// let endpoint = transaction::Payments::new(hash).cursor(cursor);
+    /// let payments = client.request(endpoint).unwrap();
+    /// #
+    /// # // Impossible to assert seeing as not all transactions have payments
+    /// ```
+    pub fn cursor(mut self, cursor: &str) -> Self {
+        self.cursor = Some(cursor.to_string());
+        self
+    }
+
+    /// Fetches all records with a given limit
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::sync::Client;
+    /// use stellar_client::endpoint::transaction;
+    ///
+    /// let client = Client::horizon_test().unwrap();
+    /// #
+    /// # let transaction_ep   = transaction::All::default().limit(1);
+    /// # let txns             = client.request(transaction_ep).unwrap();
+    /// # let txn              = &txns.records()[0];
+    /// # let hash             = txn.hash();
+    /// #
+    /// let endpoint = transaction::Payments::new(hash).limit(1);
+    /// let records = client.request(endpoint).unwrap();
+    /// #
+    /// # // Impossible to assert seeing as not all transactions have payments
+    /// ```
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Fetches all records in a set order, either ascending or descending.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::sync::Client;
+    /// use stellar_client::endpoint::{transaction, Order};
+    ///
+    /// let client = Client::horizon_test().unwrap();
+    /// #
+    /// # let transaction_ep   = transaction::All::default().limit(1);
+    /// # let txns             = client.request(transaction_ep).unwrap();
+    /// # let txn              = &txns.records()[0];
+    /// # let hash             = txn.hash();
+    /// #
+    /// let endpoint = transaction::Payments::new(hash).order(Order::Asc);
+    /// let records = client.request(endpoint).unwrap();
+    /// #
+    /// # // Impossible to assert seeing as not all transactions have payments
+    /// ```
+    pub fn order(mut self, order: Order) -> Self {
+        self.order = Some(order);
+        self
+    }
+
+    fn has_query(&self) -> bool {
+        self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
+    }
+}
+
+impl IntoRequest for Payments {
+    type Response = Records<Operation>;
+
+    fn into_request(self, host: &str) -> Result<Request<Body>> {
+        let mut uri = format!("{}/transactions/{}/payments", host, self.hash);
+        if self.has_query() {
+            uri.push_str("?");
+
+            if let Some(cursor) = self.cursor {
+                uri.push_str(&format!("cursor={}&", cursor));
+            }
+
+            if let Some(order) = self.order {
+                uri.push_str(&format!("order={}&", order.to_param()));
+            }
+
+            if let Some(limit) = self.limit {
+                uri.push_str(&format!("limit={}", limit));
+            }
+        }
+
+        let uri = Uri::from_str(&uri)?;
+        let request = Request::get(uri).body(Body::None)?;
+        Ok(request)
+    }
+}
+
+impl Cursor<Operation> for Payments {
+    fn cursor(self, cursor: &str) -> Payments {
+        self.cursor(cursor)
+    }
+}
+
+#[cfg(test)]
+mod transaction_payments_test {
+    use super::*;
+
+    #[test]
+    fn it_leaves_off_the_params_if_not_specified() {
+        let ep = Payments::new("HASH123");
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/transactions/HASH123/payments");
+        assert_eq!(req.uri().query(), None);
+    }
+
+    #[test]
+    fn it_puts_the_query_params_on_the_uri() {
+        let ep = Payments::new("HASH123")
+            .cursor("CURSOR")
+            .order(Order::Desc)
+            .limit(123);
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/transactions/HASH123/payments");
+        assert_eq!(
+            req.uri().query(),
+            Some("cursor=CURSOR&order=desc&limit=123")
+        );
     }
 }


### PR DESCRIPTION
Implements the payment for transactions endpoint and generates a request
for operations. These operations will always be payments but
actually operations under the covers. Also implement clone and cursor so
that the results can be iterated.

closes #87