### PR TITLE
Implements the Payments for Ledger endpoint

### DIFF
--- a/client/src/client/async.rs
+++ b/client/src/client/async.rs
@@ -118,8 +118,8 @@ impl Client {
         self.host == Host::HorizonProd
     }
 
-    #[allow(dead_code)] // TODO: Used for joining to end points
-    fn uri<'a>(&'a self) -> &'a str {
+    #[allow(dead_code)]
+    fn uri(&self) -> &str {
         match self.host {
             Host::HorizonTest => HORIZON_TEST_URI,
             Host::HorizonProd => HORIZON_URI,

--- a/client/src/client/sync/mod.rs
+++ b/client/src/client/sync/mod.rs
@@ -94,8 +94,8 @@ impl Client {
         self.host == Host::HorizonProd
     }
 
-    #[allow(dead_code)] // TODO: Used for joining to end points
-    fn uri<'a>(&'a self) -> &'a str {
+    #[allow(dead_code)]
+    fn uri(&self) -> &str {
         match self.host {
             Host::HorizonTest => HORIZON_TEST_URI,
             Host::HorizonProd => HORIZON_URI,

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -1,8 +1,8 @@
 //! Contains the endpoint for all ledgers.
 use error::Result;
 use std::str::FromStr;
-use stellar_resources::Ledger;
-use super::{Body, IntoRequest, Order, Records};
+use stellar_resources::{Ledger, Operation};
+use super::{Body, Cursor, IntoRequest, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all ledgers end point for the stellar horizon server. The endpoint
@@ -21,7 +21,7 @@ use http::{Request, Uri};
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct All {
     cursor: Option<String>,
     order: Option<Order>,
@@ -126,6 +126,39 @@ impl IntoRequest for All {
     }
 }
 
+impl Cursor<Ledger> for All {
+    fn cursor(self, cursor: &str) -> Self {
+        self.cursor(cursor)
+    }
+}
+
+#[cfg(test)]
+mod all_ledgers_tests {
+    use super::*;
+
+    #[test]
+    fn it_leaves_off_the_params_if_not_specified() {
+        let ep = All::default();
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/ledgers");
+        assert_eq!(req.uri().query(), None);
+    }
+
+    #[test]
+    fn it_puts_the_query_params_on_the_uri() {
+        let ep = All::default()
+            .cursor("CURSOR")
+            .limit(123)
+            .order(Order::Desc);
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/ledgers");
+        assert_eq!(
+            req.uri().query(),
+            Some("order=desc&cursor=CURSOR&limit=123")
+        );
+    }
+}
+
 /// Represents the ledger details endpoint for the stellar horizon server. The endpoint
 /// will return a single ledger's details.
 ///
@@ -140,7 +173,7 @@ impl IntoRequest for All {
 /// let endpoint    = ledger::Details::new(12345);
 /// let record      = client.request(endpoint).unwrap();
 /// #
-/// # assert!(record.sequence() == 12345); //
+/// # assert_eq!(record.sequence(), 12345);
 /// ```
 #[derive(Debug, Default)]
 pub struct Details {
@@ -170,30 +203,8 @@ impl IntoRequest for Details {
 }
 
 #[cfg(test)]
-mod all_ledgers_tests {
+mod ledger_details_tests {
     use super::*;
-
-    #[test]
-    fn it_leaves_off_the_params_if_not_specified() {
-        let ep = All::default();
-        let req = ep.into_request("https://www.google.com").unwrap();
-        assert_eq!(req.uri().path(), "/ledgers");
-        assert_eq!(req.uri().query(), None);
-    }
-
-    #[test]
-    fn it_puts_the_query_params_on_the_uri() {
-        let ep = All::default()
-            .cursor("CURSOR")
-            .limit(123)
-            .order(Order::Desc);
-        let req = ep.into_request("https://www.google.com").unwrap();
-        assert_eq!(req.uri().path(), "/ledgers");
-        assert_eq!(
-            req.uri().query(),
-            Some("order=desc&cursor=CURSOR&limit=123")
-        );
-    }
 
     #[test]
     fn it_can_make_a_ledger_details_uri() {
@@ -203,5 +214,174 @@ mod all_ledgers_tests {
             .unwrap();
         assert_eq!(request.uri().host().unwrap(), "horizon-testnet.stellar.org");
         assert_eq!(request.uri().path(), "/ledgers/12345");
+    }
+}
+
+/// Represents the payments for ledger endpoint on the stellar horizon server.
+/// The endpoint will return all the payment for a single ledger in the chain.
+///
+/// <https://www.stellar.org/developers/horizon/reference/endpoints/payments-for-ledger.html>
+///
+/// ## Example
+/// ```
+/// use stellar_client::sync::Client;
+/// use stellar_client::endpoint::{ledger, payment, transaction};
+///
+/// let client   = Client::horizon_test().unwrap();
+///
+/// // Grab payments so that we know we are getting a ledger involving payments
+/// let payments = client.request(payment::All::default()).unwrap();
+/// let payment = &payments.records()[0];
+///
+/// // Payment operations have a reference to the transaction
+/// let txn_hash = payment.transaction();
+///
+/// // The transaction details can then tell us the ledger that
+/// // the transaction was on
+/// let txn = client.request(transaction::Details::new(txn_hash)).unwrap();
+/// let sequence = txn.ledger();
+///
+/// // Now we issue a request for that ledgers payments
+/// let endpoint = ledger::Payments::new(sequence);
+/// let payments = client.request(endpoint).unwrap();
+///
+/// assert!(payments.records().len() > 0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct Payments {
+    sequence: u32,
+    cursor: Option<String>,
+    order: Option<Order>,
+    limit: Option<u32>,
+}
+
+impl Payments {
+    /// Creates a new payments endpoint struct.
+    ///
+    /// ```
+    /// use stellar_client::endpoint::ledger;
+    ///
+    /// let payments = ledger::Payments::new(123);
+    /// ```
+    pub fn new(sequence: u32) -> Payments {
+        Payments {
+            sequence,
+            cursor: None,
+            order: None,
+            limit: None,
+        }
+    }
+
+    /// Fetches all records in a set order, either ascending or descending.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::endpoint::{ledger, Order};
+    ///
+    /// # // Not making requests seeing as the main documentation has it.
+    /// # // This is just to document the usage and conserve hits to horizon.
+    /// let endpoint = ledger::Payments::new(123).order(Order::Asc);
+    /// ```
+    pub fn order(mut self, order: Order) -> Self {
+        self.order = Some(order);
+        self
+    }
+
+    /// Starts the page of results at a given cursor
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::endpoint::ledger;
+    ///
+    /// # // Not making requests seeing as the main documentation has it.
+    /// # // This is just to document the usage and conserve hits to horizon.
+    /// let endpoint = ledger::Payments::new(123).cursor("cursor");
+    /// ```
+    pub fn cursor(mut self, cursor: &str) -> Self {
+        self.cursor = Some(cursor.to_string());
+        self
+    }
+
+    /// Sets the maximum number of records to return.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::endpoint::ledger;
+    ///
+    /// # // Not making requests seeing as the main documentation has it.
+    /// # // This is just to document the usage and conserve hits to horizon.
+    /// let endpoint = ledger::Payments::new(123).limit(15);
+    /// ```
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    fn has_query(&self) -> bool {
+        self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
+    }
+}
+
+impl IntoRequest for Payments {
+    type Response = Records<Operation>;
+
+    fn into_request(self, host: &str) -> Result<Request<Body>> {
+        let mut uri = format!("{}/ledgers/{}/payments", host, self.sequence);
+
+        if self.has_query() {
+            uri.push_str("?");
+
+            if let Some(order) = self.order {
+                uri.push_str(&format!("order={}&", order.to_param()));
+            }
+
+            if let Some(cursor) = self.cursor {
+                uri.push_str(&format!("cursor={}&", cursor));
+            }
+
+            if let Some(limit) = self.limit {
+                uri.push_str(&format!("limit={}", limit));
+            }
+        }
+
+        let uri = Uri::from_str(&uri)?;
+        let request = Request::get(uri).body(Body::None)?;
+        Ok(request)
+    }
+}
+
+impl Cursor<Operation> for Payments {
+    fn cursor(self, cursor: &str) -> Self {
+        self.cursor(cursor)
+    }
+}
+
+#[cfg(test)]
+mod ledger_payments_tests {
+    use super::*;
+
+    #[test]
+    fn it_leaves_off_the_params_if_not_specified() {
+        let ep = Payments::new(123);
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/ledgers/123/payments");
+        assert_eq!(req.uri().query(), None);
+    }
+
+    #[test]
+    fn it_puts_the_query_params_on_the_uri() {
+        let ep = Payments::new(123)
+            .cursor("CURSOR")
+            .limit(123)
+            .order(Order::Desc);
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/ledgers/123/payments");
+        assert_eq!(
+            req.uri().query(),
+            Some("order=desc&cursor=CURSOR&limit=123")
+        );
     }
 }

--- a/client/src/endpoint/payment.rs
+++ b/client/src/endpoint/payment.rs
@@ -6,6 +6,7 @@ use super::{Body, IntoRequest, Order, Records};
 use http::{Request, Uri};
 
 pub use super::transaction::Payments as ForTransaction;
+pub use super::ledger::Payments as ForLedger;
 
 /// This endpoint represents all payment operations that are part of validated transactions.
 /// The endpoint will return all payments and accepts query params for a cursor, order, and limit.

--- a/client/src/endpoint/records.rs
+++ b/client/src/endpoint/records.rs
@@ -32,17 +32,17 @@ where
     T: DeserializeOwned,
 {
     /// Returns a slice of the embedded records.
-    pub fn records<'a>(&'a self) -> &'a Vec<T> {
+    pub fn records(&self) -> &Vec<T> {
         &self.records
     }
 
     /// Returns the pagination cursor for the next page
-    pub fn next_cursor<'a>(&'a self) -> &'a str {
+    pub fn next_cursor(&self) -> &str {
         &self.next
     }
 
     /// Returns the pagination cursor for the previous page
-    pub fn prev_cursor<'a>(&'a self) -> &'a str {
+    pub fn prev_cursor(&self) -> &str {
         &self.prev
     }
 }

--- a/client/src/stellar_error.rs
+++ b/client/src/stellar_error.rs
@@ -102,7 +102,7 @@ impl StellarError {
     }
 
     /// Returns a URL that can provide additional information about the stellar error.
-    pub fn url<'a>(&'a self) -> &'a str {
+    pub fn url(&self) -> &str {
         &self.url
     }
 

--- a/resources/fixtures/operations/account_merge.json
+++ b/resources/fixtures/operations/account_merge.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=799357838299137\u0026order=desc"
     },
     "transaction": {
-      "href": "/transactions/799357838299136"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "account": "GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42",
@@ -22,5 +22,6 @@
   "into": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
   "paging_token": "799357838299137",
   "type_i": 8,
-  "type": "account_merge"
+  "type": "account_merge",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/allow_trust.json
+++ b/resources/fixtures/operations/allow_trust.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=34359742465\u0026order=desc"
     },
     "transaction": {
-      "href": "/transactions/34359742464"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "asset_code": "USD",
@@ -26,5 +26,6 @@
   "trustee": "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
   "trustor": "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON",
   "type_i": 7,
-  "type": "allow_trust"
+  "type": "allow_trust",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/change_trust.json
+++ b/resources/fixtures/operations/change_trust.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=574731048718337\u0026order=desc"
     },
     "transaction": {
-      "href": "/transactions/574731048718336"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "asset_code": "CHP",
@@ -26,5 +26,6 @@
   "trustee": "GAC2ZUXVI5266NMMGDPBMXHH4BTZKJ7MMTGXRZGX2R5YLMFRYLJ7U5EA",
   "trustor": "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7QNGJMWRXRD6K5FZK5KJS4DDR",
   "type_i": 6,
-  "type": "change_trust"
+  "type": "change_trust",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/create_account.json
+++ b/resources/fixtures/operations/create_account.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=402494270214144&order=desc"
     },
     "transactions": {
-      "href": "/transactions/402494270214144"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "account": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
@@ -23,5 +23,6 @@
   "paging_token": "402494270214144",
   "starting_balance": "10000.0",
   "type_i": 0,
-  "type": "create_account"
+  "type": "create_account",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/create_passive_offer.json
+++ b/resources/fixtures/operations/create_passive_offer.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=1127729562914817\u0026order=desc"
     },
     "transaction": {
-      "href": "/transactions/1127729562914816"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "amount": "11.27827",
@@ -31,5 +31,6 @@
   },
   "selling_asset_type": "native",
   "type_i": 4,
-  "type": "create_passive_offer"
+  "type": "create_passive_offer",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/inflation.json
+++ b/resources/fixtures/operations/inflation.json
@@ -14,11 +14,12 @@
       "href": "/operations?cursor=12884914177\u0026order=desc"
     },
     "transaction": {
-      "href": "/transactions/12884914176"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "id": "12884914177",
   "paging_token": "12884914177",
   "type_i": 9,
-  "type": "inflation"
+  "type": "inflation",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/manage_data.json
+++ b/resources/fixtures/operations/manage_data.json
@@ -22,5 +22,6 @@
   "type": "manage_data",
   "type_i": 10,
   "name": "lang",
-  "value": "aW5kb25lc2lhbg=="
+  "value": "aW5kb25lc2lhbg==",
+  "transaction_hash": "e0710d3e410fe6b1ba77fcfec9e3789e94ff29b2424f1f4bf51e530dbbdf221c"
 }

--- a/resources/fixtures/operations/manage_offer.json
+++ b/resources/fixtures/operations/manage_offer.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=592323234762753\u0026order=desc"
     },
     "transaction": {
-      "href": "/transactions/592323234762752"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "amount": "100.0",
@@ -33,5 +33,6 @@
   "selling_asset_issuer": "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7QNGJMWRXRD6K5FZK5KJS4DDR",
   "selling_asset_type": "credit_alphanum4",
   "type_i": 3,
-  "type": "manage_offer"
+  "type": "manage_offer",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/path_payment.json
+++ b/resources/fixtures/operations/path_payment.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=25769807873\u0026order=desc"
     },
     "transaction": {
-      "href": "/transactions/25769807872"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "amount": "10.0",
@@ -31,5 +31,6 @@
   "source_max": "10.0",
   "to": "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
   "type_i": 2,
-  "type": "path_payment"
+  "type": "path_payment",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/payment.json
+++ b/resources/fixtures/operations/payment.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=58402965295104&order=desc"
     },
     "transactions": {
-      "href": "/transactions/58402965295104"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "amount": "200.0",
@@ -24,5 +24,6 @@
   "paging_token": "58402965295104",
   "to": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
   "type_i": 1,
-  "type": "payment"
+  "type": "payment",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/fixtures/operations/set_options.json
+++ b/resources/fixtures/operations/set_options.json
@@ -14,7 +14,7 @@
       "href": "/operations?cursor=696867033714691\u0026order=desc"
     },
     "transaction": {
-      "href": "/transactions/696867033714688"
+      "href": "/transactions/f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
     }
   },
   "signer_key": "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
@@ -33,5 +33,6 @@
     "auth_required_flag"
   ],
   "type_i": 5,
-  "type": "set_options"
+  "type": "set_options",
+  "transaction_hash": "f0222a5421ccfc4e612f11d9ff95755fbb6300df7c61442d990d498a4cd01c92"
 }

--- a/resources/src/account.rs
+++ b/resources/src/account.rs
@@ -20,13 +20,13 @@ impl Account {
     /// The canonical id of this account, suitable for use as the :id parameter
     /// for url templates that require an account’s ID. Returns a slice that lives
     /// as long as the account does.
-    pub fn id_ref<'a>(&'a self) -> &'a str {
+    pub fn id_ref(&self) -> &str {
         &self.id
     }
 
     /// The account’s public key encoded into a base32 string representation.
     /// Returns a slice that lives as long as the account does.
-    pub fn account_id_ref<'a>(&'a self) -> &'a str {
+    pub fn account_id_ref(&self) -> &str {
         &self.account_id
     }
 

--- a/resources/src/asset.rs
+++ b/resources/src/asset.rs
@@ -70,7 +70,7 @@ impl Serialize for AssetIdentifier {
 impl AssetIdentifier {
     /// The type of this asset: “credit_alphanum4”, or “credit_alphanum12”.
     /// Returns a slice that lives as long as the asset does.
-    pub fn asset_type<'a>(&'a self) -> &'a str {
+    pub fn asset_type(&self) -> &str {
         match self {
             &AssetIdentifier::Native => &"native",
             &AssetIdentifier::CreditAlphanum4(_) => &"credit_alphanum4",
@@ -80,7 +80,7 @@ impl AssetIdentifier {
 
     /// The code of this asset.
     /// Returns a slice that lives as long as the asset does.
-    pub fn code<'a>(&'a self) -> &'a str {
+    pub fn code(&self) -> &str {
         match self {
             &AssetIdentifier::Native => &"XLM",
             &AssetIdentifier::CreditAlphanum4(ref asset_id) => &asset_id.code,
@@ -99,7 +99,7 @@ impl AssetIdentifier {
 
     /// The issuer of this asset.  This corresponds to the id of an account.
     /// Returns a slice that lives as long as the asset does.
-    pub fn issuer<'a>(&'a self) -> &'a str {
+    pub fn issuer(&self) -> &str {
         match self {
             &AssetIdentifier::Native => &"Stellar Foundation",
             &AssetIdentifier::CreditAlphanum4(ref asset_id) => &asset_id.issuer,
@@ -293,19 +293,19 @@ impl Serialize for Asset {
 impl Asset {
     /// The type of this asset: “credit_alphanum4”, or “credit_alphanum12”.
     /// Returns a slice that lives as long as the asset does.
-    pub fn asset_type<'a>(&'a self) -> &'a str {
+    pub fn asset_type(&self) -> &str {
         &self.asset_identifier.asset_type()
     }
 
     /// The code of this asset.
     /// Returns a slice that lives as long as the asset does.
-    pub fn code<'a>(&'a self) -> &'a str {
+    pub fn code(&self) -> &str {
         &self.asset_identifier.code()
     }
 
     /// The issuer of this asset.  This corresponds to the id of an account.
     /// Returns a slice that lives as long as the asset does.
-    pub fn issuer<'a>(&'a self) -> &'a str {
+    pub fn issuer(&self) -> &str {
         &self.asset_identifier.issuer()
     }
 

--- a/resources/src/datum.rs
+++ b/resources/src/datum.rs
@@ -12,7 +12,7 @@ pub struct Datum {
 
 impl Datum {
     /// The value of a single key/value pair tied to a single account.
-    pub fn value<'a>(&'a self) -> &'a str {
+    pub fn value(&self) -> &str {
         &self.value.0
     }
 }

--- a/resources/src/offer.rs
+++ b/resources/src/offer.rs
@@ -95,22 +95,22 @@ impl Offer {
     }
 
     /// A paging_token suitable for use as a cursor parameter.
-    pub fn paging_token<'a>(&'a self) -> &'a str {
+    pub fn paging_token(&self) -> &str {
         &self.paging_token
     }
 
     /// The account id fo the account making this offer.
-    pub fn seller<'a>(&'a self) -> &'a str {
+    pub fn seller(&self) -> &str {
         &self.seller
     }
 
     /// The asset being sold
-    pub fn selling<'a>(&'a self) -> &'a AssetIdentifier {
+    pub fn selling(&self) -> &AssetIdentifier {
         &self.selling
     }
 
     /// The asset being bought
-    pub fn buying<'a>(&'a self) -> &'a AssetIdentifier {
+    pub fn buying(&self) -> &AssetIdentifier {
         &self.buying
     }
 

--- a/resources/src/operation/account_merge.rs
+++ b/resources/src/operation/account_merge.rs
@@ -16,12 +16,12 @@ impl AccountMerge {
     }
 
     /// The account being deleted from the ledger
-    pub fn account<'a>(&'a self) -> &'a str {
+    pub fn account(&self) -> &str {
         &self.account
     }
 
     /// Account ID where funds of deleted account were transferred.
-    pub fn into<'a>(&'a self) -> &'a str {
+    pub fn into(&self) -> &str {
         &self.into
     }
 }

--- a/resources/src/operation/account_merge.rs
+++ b/resources/src/operation/account_merge.rs
@@ -1,5 +1,5 @@
 /// Removes the account and transfers all remaining XLM to the destination account.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct AccountMerge {
     account: String,
     into: String,
@@ -16,12 +16,12 @@ impl AccountMerge {
     }
 
     /// The account being deleted from the ledger
-    pub fn account(&self) -> &String {
+    pub fn account<'a>(&'a self) -> &'a str {
         &self.account
     }
 
     /// Account ID where funds of deleted account were transferred.
-    pub fn into(&self) -> &String {
+    pub fn into<'a>(&'a self) -> &'a str {
         &self.into
     }
 }

--- a/resources/src/operation/allow_trust.rs
+++ b/resources/src/operation/allow_trust.rs
@@ -5,7 +5,7 @@ use asset::AssetIdentifier;
 ///
 ///Heads up! Unless the issuing account has AUTH_REVOCABLE_FLAG set than the “authorized” flag can
 ///only be set and never cleared.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct AllowTrust {
     trustee: String,
     trustor: String,
@@ -30,12 +30,12 @@ impl AllowTrust {
     }
 
     /// Trustee account.
-    pub fn trustee(&self) -> &String {
+    pub fn trustee<'a>(&'a self) -> &'a str {
         &self.trustee
     }
 
     /// Trustor account.
-    pub fn trustor(&self) -> &String {
+    pub fn trustor<'a>(&'a self) -> &'a str {
         &self.trustor
     }
 

--- a/resources/src/operation/allow_trust.rs
+++ b/resources/src/operation/allow_trust.rs
@@ -30,12 +30,12 @@ impl AllowTrust {
     }
 
     /// Trustee account.
-    pub fn trustee<'a>(&'a self) -> &'a str {
+    pub fn trustee(&self) -> &str {
         &self.trustee
     }
 
     /// Trustor account.
-    pub fn trustor<'a>(&'a self) -> &'a str {
+    pub fn trustor(&self) -> &str {
         &self.trustor
     }
 

--- a/resources/src/operation/change_trust.rs
+++ b/resources/src/operation/change_trust.rs
@@ -3,7 +3,7 @@ use amount::Amount;
 
 /// Use “Change Trust” operation to create/update/delete a trust line from the source account to
 /// another. The issuer being trusted and the asset code are in the given Asset object.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ChangeTrust {
     trustee: String,
     trustor: String,
@@ -28,12 +28,12 @@ impl ChangeTrust {
     }
 
     /// Trustee account.
-    pub fn trustee(&self) -> &String {
+    pub fn trustee<'a>(&'a self) -> &'a str {
         &self.trustee
     }
 
     /// Trustor account.
-    pub fn trustor(&self) -> &String {
+    pub fn trustor<'a>(&'a self) -> &'a str {
         &self.trustor
     }
 

--- a/resources/src/operation/change_trust.rs
+++ b/resources/src/operation/change_trust.rs
@@ -28,12 +28,12 @@ impl ChangeTrust {
     }
 
     /// Trustee account.
-    pub fn trustee<'a>(&'a self) -> &'a str {
+    pub fn trustee(&self) -> &str {
         &self.trustee
     }
 
     /// Trustor account.
-    pub fn trustor<'a>(&'a self) -> &'a str {
+    pub fn trustor(&self) -> &str {
         &self.trustor
     }
 

--- a/resources/src/operation/create_account.rs
+++ b/resources/src/operation/create_account.rs
@@ -1,7 +1,7 @@
 use amount::Amount;
 
 /// A create account operation represents a new account creation.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct CreateAccount {
     account: String,
     funder: String,
@@ -18,12 +18,12 @@ impl CreateAccount {
         }
     }
     /// The public address of a new account that was funded.
-    pub fn account(&self) -> &String {
+    pub fn account<'a>(&'a self) -> &'a str {
         &self.account
     }
 
     /// The public address of the account that funded a new account.
-    pub fn funder(&self) -> &String {
+    pub fn funder<'a>(&'a self) -> &'a str {
         &self.funder
     }
 

--- a/resources/src/operation/create_account.rs
+++ b/resources/src/operation/create_account.rs
@@ -18,12 +18,12 @@ impl CreateAccount {
         }
     }
     /// The public address of a new account that was funded.
-    pub fn account<'a>(&'a self) -> &'a str {
+    pub fn account(&self) -> &str {
         &self.account
     }
 
     /// The public address of the account that funded a new account.
-    pub fn funder<'a>(&'a self) -> &'a str {
+    pub fn funder(&self) -> &str {
         &self.funder
     }
 

--- a/resources/src/operation/create_passive_offer.rs
+++ b/resources/src/operation/create_passive_offer.rs
@@ -5,13 +5,12 @@ use offer::PriceRatio;
 /// “Create Passive Offer” operation creates an offer that won’t consume a counter offer that
 /// exactly matches this offer. This is useful for offers just used as 1:1 exchanges for path
 /// payments. Use Manage Offer to manage this offer after using this operation to create it.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct CreatePassiveOffer {
     offer_id: i64,
     selling: AssetIdentifier,
     buying: AssetIdentifier,
     amount: Amount,
-    #[serde(rename = "price_r")]
     price_ratio: PriceRatio,
     price: Amount,
 }

--- a/resources/src/operation/manage_data.rs
+++ b/resources/src/operation/manage_data.rs
@@ -15,12 +15,12 @@ impl ManageData {
     }
 
     /// The key of the data value to update
-    pub fn name<'a>(&'a self) -> &'a str {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
     /// The new data value associated with the named key
-    pub fn value<'a>(&'a self) -> &'a str {
+    pub fn value(&self) -> &str {
         &self.value
     }
 }

--- a/resources/src/operation/manage_data.rs
+++ b/resources/src/operation/manage_data.rs
@@ -1,5 +1,5 @@
 /// Set, modify or delete a Data Entry (name/value pair) for an account.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ManageData {
     name: String,
     value: String,
@@ -15,12 +15,12 @@ impl ManageData {
     }
 
     /// The key of the data value to update
-    pub fn name(&self) -> &String {
+    pub fn name<'a>(&'a self) -> &'a str {
         &self.name
     }
 
     /// The new data value associated with the named key
-    pub fn value(&self) -> &String {
+    pub fn value<'a>(&'a self) -> &'a str {
         &self.value
     }
 }

--- a/resources/src/operation/manage_offer.rs
+++ b/resources/src/operation/manage_offer.rs
@@ -4,13 +4,12 @@ use offer::PriceRatio;
 
 /// A “Manage Offer” operation can create, update or delete an offer to trade assets in the Stellar
 /// network. It specifies an issuer, a price and amount of a given asset to buy or sell.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ManageOffer {
     offer_id: i64,
     selling: AssetIdentifier,
     buying: AssetIdentifier,
     amount: Amount,
-    #[serde(rename = "price_r")]
     price_ratio: PriceRatio,
     price: Amount,
 }

--- a/resources/src/operation/mod.rs
+++ b/resources/src/operation/mod.rs
@@ -93,12 +93,12 @@ impl Operation {
     }
 
     /// A paging token suitable for use as a cursor parameter.
-    pub fn paging_token<'a>(&'a self) -> &'a str {
+    pub fn paging_token(&self) -> &str {
         &self.paging_token
     }
 
     /// The has for the transaction that the operation was part of
-    pub fn transaction<'a>(&'a self) -> &'a str {
+    pub fn transaction(&self) -> &str {
         &self.transaction_hash
     }
 

--- a/resources/src/operation/path_payment.rs
+++ b/resources/src/operation/path_payment.rs
@@ -4,7 +4,7 @@ use asset::AssetIdentifier;
 /// A path payment operation represents a payment from one account to another through a path. This
 /// type of payment starts as one type of asset and ends as another type of asset. There can be
 /// other assets that are traded into and out of along the path.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct PathPayment {
     from: String,
     to: String,
@@ -37,12 +37,12 @@ impl PathPayment {
         }
     }
     /// Sender of a payment.
-    pub fn from(&self) -> &String {
+    pub fn from<'a>(&'a self) -> &'a str {
         &self.from
     }
 
     /// Destination of a payment.
-    pub fn to(&self) -> &String {
+    pub fn to<'a>(&'a self) -> &'a str {
         &self.to
     }
 

--- a/resources/src/operation/path_payment.rs
+++ b/resources/src/operation/path_payment.rs
@@ -37,12 +37,12 @@ impl PathPayment {
         }
     }
     /// Sender of a payment.
-    pub fn from<'a>(&'a self) -> &'a str {
+    pub fn from(&self) -> &str {
         &self.from
     }
 
     /// Destination of a payment.
-    pub fn to<'a>(&'a self) -> &'a str {
+    pub fn to(&self) -> &str {
         &self.to
     }
 

--- a/resources/src/operation/payment.rs
+++ b/resources/src/operation/payment.rs
@@ -3,7 +3,7 @@ use asset::AssetIdentifier;
 
 /// A payment operation represents a payment from one account to another. This payment can be
 /// either a simple native asset payment or a fiat asset payment.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Payment {
     from: String,
     to: String,
@@ -23,12 +23,12 @@ impl Payment {
     }
 
     /// The public address of the account making a payment.
-    pub fn from(&self) -> &String {
+    pub fn from<'a>(&'a self) -> &'a str {
         &self.from
     }
 
     /// The public address of the account receiving a payment.
-    pub fn to(&self) -> &String {
+    pub fn to<'a>(&'a self) -> &'a str {
         &self.to
     }
 

--- a/resources/src/operation/payment.rs
+++ b/resources/src/operation/payment.rs
@@ -23,12 +23,12 @@ impl Payment {
     }
 
     /// The public address of the account making a payment.
-    pub fn from<'a>(&'a self) -> &'a str {
+    pub fn from(&self) -> &str {
         &self.from
     }
 
     /// The public address of the account receiving a payment.
-    pub fn to<'a>(&'a self) -> &'a str {
+    pub fn to(&self) -> &str {
         &self.to
     }
 

--- a/resources/src/operation/set_options.rs
+++ b/resources/src/operation/set_options.rs
@@ -50,7 +50,7 @@ impl SetOptions {
     }
 
     /// The public key of the new signer.
-    pub fn signer_key<'a>(&'a self) -> &'a str {
+    pub fn signer_key(&self) -> &str {
         &self.signer_key
     }
 
@@ -80,7 +80,7 @@ impl SetOptions {
     }
 
     /// The home domain used for reverse federation lookup
-    pub fn home_domain<'a>(&'a self) -> &'a str {
+    pub fn home_domain(&self) -> &str {
         &self.home_domain
     }
 

--- a/resources/src/operation/set_options.rs
+++ b/resources/src/operation/set_options.rs
@@ -10,7 +10,7 @@ use asset::Flag;
 /// Set the account’s inflation destination.
 /// Add new signers to the account.
 /// Set home domain.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct SetOptions {
     signer_key: String,
     signer_weight: u8,
@@ -50,7 +50,7 @@ impl SetOptions {
     }
 
     /// The public key of the new signer.
-    pub fn signer_key(&self) -> &String {
+    pub fn signer_key<'a>(&'a self) -> &'a str {
         &self.signer_key
     }
 
@@ -80,7 +80,7 @@ impl SetOptions {
     }
 
     /// The home domain used for reverse federation lookup
-    pub fn home_domain(&self) -> &String {
+    pub fn home_domain<'a>(&'a self) -> &'a str {
         &self.home_domain
     }
 

--- a/resources/src/operation/test.rs
+++ b/resources/src/operation/test.rs
@@ -15,7 +15,13 @@ mod errors_on_missing_fields_for_type {
             #[test]
             fn $type_to_check() {
                 let json = format!(
-                    r#"{{"id":"1","paging_token":"7","type_i":{},"type":"{}"}}"#,
+                    r#"{{
+                        "id":"1",
+                        "paging_token":"7",
+                        "type_i":{},
+                        "type":"{}",
+                        "transaction_hash":"123"
+                    }}"#,
                     $type_i,
                     stringify!($type_to_check),
                 );

--- a/resources/src/trade.rs
+++ b/resources/src/trade.rs
@@ -185,12 +185,12 @@ struct TradeRepresentation {
 
 impl Trade {
     /// The id of the trade.
-    pub fn id<'a>(&'a self) -> &'a str {
+    pub fn id(&self) -> &str {
         &self.id
     }
 
     /// A paging_token suitable for use as a cursor parameter.
-    pub fn paging_token<'a>(&'a self) -> &'a str {
+    pub fn paging_token(&self) -> &str {
         &self.paging_token
     }
 
@@ -200,17 +200,17 @@ impl Trade {
     }
 
     /// The id of the offer involved in the trade.
-    pub fn offer_id<'a>(&'a self) -> &'a str {
+    pub fn offer_id(&self) -> &str {
         &self.offer_id
     }
 
     /// The base account of the trade that received the counter asset.
-    pub fn base_account<'a>(&'a self) -> &'a str {
+    pub fn base_account(&self) -> &str {
         &self.base_account
     }
 
     /// The asset offerred from the base party of the trade.
-    pub fn base_asset<'a>(&'a self) -> &'a AssetIdentifier {
+    pub fn base_asset(&self) -> &AssetIdentifier {
         &self.base_asset
     }
 
@@ -220,12 +220,12 @@ impl Trade {
     }
 
     /// The counter account of the trade that received the base asset.
-    pub fn counter_account<'a>(&'a self) -> &'a str {
+    pub fn counter_account(&self) -> &str {
         &self.counter_account
     }
 
     /// The asset offerred from the counter party of the trade.
-    pub fn counter_asset<'a>(&'a self) -> &'a AssetIdentifier {
+    pub fn counter_asset(&self) -> &AssetIdentifier {
         &self.counter_asset
     }
 


### PR DESCRIPTION
Implements the payments route for ledgers. In doing so I implemented
several other changes to facilitate it:

1. Add clone + cursor to the All endpoint for ledgers
2. Remove Deserialize and add Clone to all Operation types
3. Migrate from returning &Sting to returning &str on operation getters
4. Added transaction_hash to operation as a common attribute (not
documented but appears in all the responses).

closes #86