### PR TITLE
[#78] Adds payments to the account endpoint

### DIFF
--- a/client/src/endpoint/payment.rs
+++ b/client/src/endpoint/payment.rs
@@ -7,6 +7,7 @@ use http::{Request, Uri};
 
 pub use super::transaction::Payments as ForTransaction;
 pub use super::ledger::Payments as ForLedger;
+pub use super::account::Payments as ForAccount;
 
 /// This endpoint represents all payment operations that are part of validated transactions.
 /// The endpoint will return all payments and accepts query params for a cursor, order, and limit.


### PR DESCRIPTION
This implements the `payments` action on the `account` endpoint, returning a series of `Operation` records: https://www.stellar.org/developers/horizon/reference/endpoints/payments-for-account.html

This was largely copy 🍝 from the `transactions` action, so tell me where I'm off base here.

This closes #78 