### PR TITLE
Implements ordering for the CLI

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,6 +1,6 @@
 use clap::ArgMatches;
-use stellar_client::{sync, endpoint::{account, Order}, error::Result, sync::Client};
-use super::pager::Pager;
+use stellar_client::{sync, endpoint::account, error::Result, sync::Client};
+use super::{ordering, pager::Pager};
 
 pub fn details<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let id = matches.value_of("ID").expect("ID is required");
@@ -18,7 +18,7 @@ pub fn transactions<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
 
     let id = matches.value_of("ID").expect("ID is required");
     let endpoint = account::Transactions::new(id)
-        .order(Order::Desc)
+        .order(ordering::from_arg(matches))
         .limit(pager.horizon_page_limit() as u32);
     let iter = sync::Iter::new(&client, endpoint);
 

--- a/cli/src/assets.rs
+++ b/cli/src/assets.rs
@@ -1,13 +1,15 @@
-use stellar_client::{endpoint::{asset, Order}, error::Result, sync::{self, Client}};
+use stellar_client::{endpoint::asset, error::Result, sync::{self, Client}};
 use clap::ArgMatches;
-use super::pager::Pager;
+use super::{ordering, pager::Pager};
 
+/// Using a client and the arguments from the command line, iterates over the results
+/// and displays them to the end user.
 pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
 
     let endpoint = {
         let mut endpoint = asset::All::default()
-            .order(Order::Asc)
+            .order(ordering::from_arg(matches))
             .limit(pager.horizon_page_limit() as u32);
 
         if let Some(code) = matches.value_of("code") {
@@ -16,6 +18,7 @@ pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
         if let Some(issuer) = matches.value_of("issuer") {
             endpoint = endpoint.asset_issuer(issuer)
         }
+
         endpoint
     };
     let iter = sync::Iter::new(&client, endpoint);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+//! A basic CLI for interactions with the stellar network.
 extern crate clap;
 extern crate stellar_client;
 extern crate stellar_resources;
@@ -6,9 +8,16 @@ use clap::{App, AppSettings, Arg, SubCommand};
 use stellar_client::{error::Error, sync::Client};
 
 mod pager;
+mod ordering;
 use pager::Pager;
 
 fn build_app<'a, 'b>() -> App<'a, 'b> {
+    macro_rules! listable {
+        ($e:expr) => {
+            Pager::add(ordering::add($e))
+        }
+    }
+
     App::new("Stellar CLI")
         .version("0.1")
         .about("Access the stellar horizon API via the command line.")
@@ -47,7 +56,7 @@ fn build_app<'a, 'b>() -> App<'a, 'b> {
                         ),
                 )
                 .subcommand(
-                    Pager::add(
+                    listable!(
                         SubCommand::with_name("transactions")
                             .about("Fetch transactions for an account")
                             .arg(
@@ -63,7 +72,7 @@ fn build_app<'a, 'b>() -> App<'a, 'b> {
             SubCommand::with_name("transactions")
                 .about("Access lists of transactions")
                 .setting(AppSettings::SubcommandRequired)
-                .subcommand(Pager::add(SubCommand::with_name("all").about("Fetch all transactions"))
+                .subcommand(listable!(SubCommand::with_name("all").about("Fetch all transactions"))
             ),
         )
         .subcommand(
@@ -71,7 +80,7 @@ fn build_app<'a, 'b>() -> App<'a, 'b> {
                 .about("Access lists of assets")
                 .setting(AppSettings::SubcommandRequired)
                 .subcommand(
-                    Pager::add(
+                    listable!(
                         SubCommand::with_name("all")
                             .about("Fetch all assets")
                             .arg(

--- a/cli/src/ordering.rs
+++ b/cli/src/ordering.rs
@@ -1,0 +1,60 @@
+use clap::{App, Arg, ArgMatches};
+use stellar_client::endpoint::{Order, Order::Asc, Order::Desc};
+
+static ARG_NAME: &'static str = "order";
+static ASC: &'static str = "asc";
+static DESC: &'static str = "desc";
+
+/// Appends the order arg to the app and returns a newly owned app.
+pub fn add<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+    app.arg(
+        Arg::with_name(ARG_NAME)
+            .long("order")
+            .short("o")
+            .takes_value(true)
+            .default_value(DESC)
+            .possible_values(&[ASC, DESC])
+            .help("Specify the order to return the results"),
+    )
+}
+
+/// Parses the argument matches and returns the order to use.
+pub fn from_arg<'a>(arg: &'a ArgMatches) -> Order {
+    match arg.value_of(ARG_NAME) {
+        Some(s) if s == ASC => Asc,
+        Some(s) if s == DESC => Desc,
+        _ => Desc,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_app<'a, 'b>() -> App<'a, 'b> {
+        add(App::new("test"))
+    }
+
+    fn get_matches(args: Vec<&str>) -> ArgMatches {
+        let app = test_app();
+        app.get_matches_from(args)
+    }
+
+    #[test]
+    fn it_sets_desc() {
+        let order = from_arg(&get_matches(vec!["test", "--order", "desc"]));
+        assert_eq!(order, Desc);
+    }
+
+    #[test]
+    fn it_sets_asc() {
+        let order = from_arg(&get_matches(vec!["test", "--order", "asc"]));
+        assert_eq!(order, Asc);
+    }
+
+    #[test]
+    fn it_defaults_to_desc() {
+        let order = from_arg(&get_matches(vec!["test"]));
+        assert_eq!(order, Desc);
+    }
+}

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -1,11 +1,11 @@
-use stellar_client::{endpoint::{transaction, Order}, error::Result, sync::{self, Client}};
+use stellar_client::{endpoint::transaction, error::Result, sync::{self, Client}};
 use clap::ArgMatches;
-use super::pager::Pager;
+use super::{ordering, pager::Pager};
 
 pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
     let endpoint = transaction::All::default()
-        .order(Order::Desc)
+        .order(ordering::from_arg(matches))
         .limit(pager.horizon_page_limit() as u32);
     let iter = sync::Iter::new(&client, endpoint);
 

--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -218,7 +218,7 @@ impl IntoRequest for Transactions {
             }
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(limit) = self.limit {
@@ -396,7 +396,7 @@ impl IntoRequest for Effects {
             }
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(limit) = self.limit {
@@ -567,7 +567,7 @@ impl IntoRequest for Operations {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {

--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -168,7 +168,7 @@ impl IntoRequest for All {
             }
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {

--- a/client/src/endpoint/effect.rs
+++ b/client/src/endpoint/effect.rs
@@ -110,7 +110,7 @@ impl IntoRequest for All {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -108,7 +108,7 @@ impl IntoRequest for All {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {
@@ -335,7 +335,7 @@ impl IntoRequest for Payments {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {
@@ -497,7 +497,7 @@ impl IntoRequest for Transactions {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {
@@ -661,7 +661,7 @@ impl IntoRequest for Effects {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {
@@ -824,7 +824,7 @@ impl IntoRequest for Operations {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -33,7 +33,7 @@ pub trait IntoRequest {
 }
 
 /// The order to return results in.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Order {
     /// Order the results ascending
     Asc,
@@ -41,11 +41,24 @@ pub enum Order {
     Desc,
 }
 
-impl Order {
-    pub(crate) fn to_param(&self) -> String {
+use std::string::ToString;
+
+impl ToString for Order {
+    fn to_string(&self) -> String {
         match *self {
             Order::Asc => "asc".to_string(),
             Order::Desc => "desc".to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod order_tests {
+    use super::*;
+
+    #[test]
+    fn it_can_become_a_string() {
+        assert_eq!(Order::Asc.to_string(), "asc");
+        assert_eq!(Order::Desc.to_string(), "desc");
     }
 }

--- a/client/src/endpoint/operation.rs
+++ b/client/src/endpoint/operation.rs
@@ -111,7 +111,7 @@ impl IntoRequest for All {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {

--- a/client/src/endpoint/payment.rs
+++ b/client/src/endpoint/payment.rs
@@ -111,7 +111,7 @@ impl IntoRequest for All {
             uri.push_str("?");
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(cursor) = self.cursor {

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -115,7 +115,7 @@ impl IntoRequest for All {
             }
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(limit) = self.limit {
@@ -358,7 +358,7 @@ impl IntoRequest for Payments {
             }
 
             if let Some(order) = self.order {
-                uri.push_str(&format!("order={}&", order.to_param()));
+                uri.push_str(&format!("order={}&", order.to_string()));
             }
 
             if let Some(limit) = self.limit {

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -28,7 +28,7 @@ pub enum Error {
     /// An error occurred while parsing the json
     ///
     /// <https://docs.serde.rs/serde_json/error/struct.Error.html>
-    ParseError(serde_json::error::Error),
+    JsonParseError(serde_json::error::Error),
     /// Catch-all for reqwest error handling
     Reqwest(reqwest::Error),
     #[doc(hidden)]
@@ -45,7 +45,7 @@ impl StdError for Error {
             Error::BadSSL => "Unable to resolve tls",
             Error::Http(ref inner) => inner.description(),
             Error::Reqwest(ref inner) => inner.description(),
-            Error::ParseError(ref inner) => inner.description(),
+            Error::JsonParseError(ref inner) => inner.description(),
             Error::BadResponse(ref inner) => inner.description(),
             Error::ServerError => "An unknown error on the server has occurred",
             Error::__Nonexhaustive => unreachable!(),
@@ -97,7 +97,7 @@ impl From<reqwest::Error> for Error {
 
 impl From<serde_json::error::Error> for Error {
     fn from(inner: serde_json::error::Error) -> Self {
-        Error::ParseError(inner)
+        Error::JsonParseError(inner)
     }
 }
 


### PR DESCRIPTION
Implements ordering of the records in the cli (closes #114). In addition
to the cli it also changes the `to_param` to a `ToString`
implementation. Along with that it renames the ParseError to
JsonParseError to be more precise.

FYI: This may conflict with in progress work when merged.