### PR TITLE
Remove the extra type definitions from Cursor

### DIFF
--- a/client/src/client/sync/iter.rs
+++ b/client/src/client/sync/iter.rs
@@ -21,7 +21,7 @@ use error::Result;
 #[derive(Debug)]
 pub struct Iter<'a, T, E>
 where
-    E: IntoRequest<Response = Records<T>> + Clone + Cursor<T>,
+    E: IntoRequest<Response = Records<T>> + Clone + Cursor,
     T: DeserializeOwned + Clone,
 {
     client: &'a Client,
@@ -33,7 +33,7 @@ where
 
 impl<'a, T, E> Iter<'a, T, E>
 where
-    E: IntoRequest<Response = Records<T>> + Clone + Cursor<T>,
+    E: IntoRequest<Response = Records<T>> + Clone + Cursor,
     T: DeserializeOwned + Clone,
 {
     /// Creates a new iterator for the client and endpoint.
@@ -72,7 +72,7 @@ where
 
 impl<'a, T, E> Iterator for Iter<'a, T, E>
 where
-    E: IntoRequest<Response = Records<T>> + Clone + Cursor<T>,
+    E: IntoRequest<Response = Records<T>> + Clone + Cursor,
     T: DeserializeOwned + Clone,
 {
     type Item = Result<T>;

--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -199,7 +199,7 @@ impl Transactions {
     }
 }
 
-impl Cursor<Transaction> for Transactions {
+impl Cursor for Transactions {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }
@@ -585,7 +585,7 @@ impl IntoRequest for Operations {
     }
 }
 
-impl Cursor<Operation> for Operations {
+impl Cursor for Operations {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }

--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -145,7 +145,7 @@ impl All {
     }
 }
 
-impl Cursor<Asset> for All {
+impl Cursor for All {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -126,7 +126,7 @@ impl IntoRequest for All {
     }
 }
 
-impl Cursor<Ledger> for All {
+impl Cursor for All {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }
@@ -353,7 +353,7 @@ impl IntoRequest for Payments {
     }
 }
 
-impl Cursor<Operation> for Payments {
+impl Cursor for Payments {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }
@@ -515,7 +515,7 @@ impl IntoRequest for Transactions {
     }
 }
 
-impl Cursor<Transaction> for Transactions {
+impl Cursor for Transactions {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }
@@ -679,7 +679,7 @@ impl IntoRequest for Effects {
     }
 }
 
-impl Cursor<Effect> for Effects {
+impl Cursor for Effects {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }
@@ -842,7 +842,7 @@ impl IntoRequest for Operations {
     }
 }
 
-impl Cursor<Operation> for Operations {
+impl Cursor for Operations {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }

--- a/client/src/endpoint/operation.rs
+++ b/client/src/endpoint/operation.rs
@@ -107,7 +107,7 @@ impl IntoRequest for All {
     }
 }
 
-impl Cursor<Operation> for All {
+impl Cursor for All {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }

--- a/client/src/endpoint/records.rs
+++ b/client/src/endpoint/records.rs
@@ -1,13 +1,9 @@
 use http;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};
-use super::IntoRequest;
 use std;
 
 /// Declares that this endpoint has a cursor and can have it set.
-pub trait Cursor<T>: IntoRequest<Response = Records<T>>
-where
-    T: DeserializeOwned,
-{
+pub trait Cursor {
     /// Sets a cursor on the endpoint.
     fn cursor(self, cursor: &str) -> Self;
 }

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -129,7 +129,7 @@ impl IntoRequest for All {
     }
 }
 
-impl Cursor<Transaction> for All {
+impl Cursor for All {
     fn cursor(self, cursor: &str) -> Self {
         self.cursor(cursor)
     }
@@ -372,7 +372,7 @@ impl IntoRequest for Payments {
     }
 }
 
-impl Cursor<Operation> for Payments {
+impl Cursor for Payments {
     fn cursor(self, cursor: &str) -> Payments {
         self.cursor(cursor)
     }


### PR DESCRIPTION
The cursor trait was defining itself as needing to be implement against
an endpoint that was defined with a response that was a Records struct.
However, this is not a requirement, however, for the ability to set the
cursor.

### Is there a GIF that reflects how this work made you feel?
![belt_and_suspenders](https://user-images.githubusercontent.com/2043529/38459065-fbc329da-3a59-11e8-8f3d-d7ebb1ecb620.gif)
