### PR TITLE
Add Cursor to the CLI

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,6 +1,6 @@
 use clap::ArgMatches;
 use stellar_client::{sync, endpoint::account, error::Result, sync::Client};
-use super::{ordering, pager::Pager};
+use super::{cursor, ordering, pager::Pager};
 
 pub fn details<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let id = matches.value_of("ID").expect("ID is required");
@@ -17,9 +17,12 @@ pub fn transactions<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
 
     let id = matches.value_of("ID").expect("ID is required");
-    let endpoint = account::Transactions::new(id)
-        .order(ordering::from_arg(matches))
-        .limit(pager.horizon_page_limit() as u32);
+    let endpoint = {
+        let endpoint = account::Transactions::new(id)
+            .order(ordering::from_arg(matches))
+            .limit(pager.horizon_page_limit() as u32);
+        cursor::assign_from_arg(matches, endpoint)
+    };
     let iter = sync::Iter::new(&client, endpoint);
 
     let mut res = Ok(());

--- a/cli/src/assets.rs
+++ b/cli/src/assets.rs
@@ -1,6 +1,6 @@
 use stellar_client::{endpoint::asset, error::Result, sync::{self, Client}};
 use clap::ArgMatches;
-use super::{ordering, pager::Pager};
+use super::{cursor, ordering, pager::Pager};
 
 /// Using a client and the arguments from the command line, iterates over the results
 /// and displays them to the end user.
@@ -13,13 +13,12 @@ pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
             .limit(pager.horizon_page_limit() as u32);
 
         if let Some(code) = matches.value_of("code") {
-            endpoint = endpoint.asset_code(code)
+            endpoint = endpoint.asset_code(code);
         }
         if let Some(issuer) = matches.value_of("issuer") {
-            endpoint = endpoint.asset_issuer(issuer)
+            endpoint = endpoint.asset_issuer(issuer);
         }
-
-        endpoint
+        cursor::assign_from_arg(matches, endpoint)
     };
     let iter = sync::Iter::new(&client, endpoint);
 

--- a/cli/src/cursor.rs
+++ b/cli/src/cursor.rs
@@ -1,0 +1,66 @@
+use clap::{App, Arg, ArgMatches};
+use stellar_client::endpoint::Cursor;
+
+static ARG_NAME: &'static str = "cursor";
+
+/// Appends the cursor arg to the app and returns a newly owned app.
+pub fn add<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+    app.arg(
+        Arg::with_name(ARG_NAME)
+            .long(ARG_NAME)
+            .takes_value(true)
+            .help("Specify the cursor of the oldest record to return."),
+    )
+}
+
+/// Parses the argument matches and returns the order to use.
+pub fn assign_from_arg<'a, C>(arg: &'a ArgMatches, endpoint: C) -> C
+where
+    C: Cursor,
+{
+    match arg.value_of(ARG_NAME) {
+        Some(cur) => endpoint.cursor(cur),
+        None => endpoint,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestCurse {
+        cursor: Option<String>,
+    }
+
+    impl Cursor for TestCurse {
+        fn cursor(mut self, cursor: &str) -> TestCurse {
+            self.cursor = Some(cursor.to_owned());
+            self
+        }
+    }
+
+    fn test_app<'a, 'b>() -> App<'a, 'b> {
+        add(App::new("test"))
+    }
+
+    fn get_matches(args: Vec<&str>) -> ArgMatches {
+        let app = test_app();
+        app.get_matches_from(args)
+    }
+
+    #[test]
+    fn it_sets_the_cursor_if_provided() {
+        let arg_matches = get_matches(vec!["test", "--cursor", "123abc"]);
+        let cursor = TestCurse { cursor: None };
+        let cursor = assign_from_arg(&arg_matches, cursor);
+        assert_eq!(cursor.cursor, Some("123abc".to_owned()));
+    }
+
+    #[test]
+    fn it_defaults_to_none() {
+        let arg_matches = get_matches(vec!["test"]);
+        let cursor = TestCurse { cursor: None };
+        let cursor = assign_from_arg(&arg_matches, cursor);
+        assert_eq!(cursor.cursor, None);
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,12 +9,17 @@ use stellar_client::{error::Error, sync::Client};
 
 mod pager;
 mod ordering;
+mod cursor;
 use pager::Pager;
 
 fn build_app<'a, 'b>() -> App<'a, 'b> {
     macro_rules! listable {
         ($e:expr) => {
-            Pager::add(ordering::add($e))
+            Pager::add(
+                ordering::add(
+                    cursor::add($e)
+                )
+            )
         }
     }
 

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -1,12 +1,15 @@
 use stellar_client::{endpoint::transaction, error::Result, sync::{self, Client}};
 use clap::ArgMatches;
-use super::{ordering, pager::Pager};
+use super::{cursor, ordering, pager::Pager};
 
 pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
-    let endpoint = transaction::All::default()
-        .order(ordering::from_arg(matches))
-        .limit(pager.horizon_page_limit() as u32);
+    let endpoint = {
+        let endpoint = transaction::All::default()
+            .order(ordering::from_arg(matches))
+            .limit(pager.horizon_page_limit() as u32);
+        cursor::assign_from_arg(matches, endpoint)
+    };
     let iter = sync::Iter::new(&client, endpoint);
 
     let mut res = Ok(());


### PR DESCRIPTION
Added the cursor argument to the clap app by adding a cursor option
to the listable macro defined in main.  If an argument is supplied
to the cursor it is added to the endpoint before querying the
Horizon API.

Resolves #113 

### Is there a GIF that reflects how this work made you feel?
![body positivity gif-downsized](https://user-images.githubusercontent.com/5183236/38459544-b73e6a08-3a5f-11e8-8273-dda89af7e156.gif)
