### PR TITLE
Implement operations for transaction endpoint

### DIFF
--- a/client/src/endpoint/operation.rs
+++ b/client/src/endpoint/operation.rs
@@ -7,6 +7,7 @@ use http::{Request, Uri};
 
 pub use super::account::Operations as ForAccount;
 pub use super::ledger::Operations as ForLedger;
+pub use super::transaction::Operations as ForTransaction;
 
 /// This endpoint represents all operations that have resulted from successful transactions in Stellar.
 /// The endpoint will return all operations and accepts query params for a cursor, order, and limit.

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -162,7 +162,7 @@ mod all_transactions_test {
     }
 }
 
-/// Represents the details for a single transaction.
+/// Represents the details for a singular transaction.
 ///
 /// <https://www.stellar.org/developers/horizon/reference/endpoints/transactions-single.html>
 ///
@@ -222,7 +222,7 @@ mod transaction_details_tests {
     }
 }
 
-/// Returns the payments associated with a single transactions.
+/// Returns the payments associated with a singular transactions.
 ///
 /// <https://www.stellar.org/developers/horizon/reference/endpoints/payments-for-transaction.html>
 ///
@@ -230,17 +230,21 @@ mod transaction_details_tests {
 ///
 /// ```
 /// use stellar_client::sync::Client;
-/// use stellar_client::endpoint::transaction;
+/// use stellar_client::endpoint::{transaction, payment};
 ///
 /// let client   = Client::horizon_test().unwrap();
-/// # let transaction_ep   = transaction::All::default().limit(1);
-/// # let txns             = client.request(transaction_ep).unwrap();
-/// # let txn              = &txns.records()[0];
-/// # let hash             = txn.hash();
-/// let endpoint = transaction::Payments::new(hash);
-/// let payments = client.request(endpoint).unwrap();
-/// #
-/// # // Impossible to assert seeing as not all transactions have payments
+///
+/// // Grab a payment from the all payments end point
+/// let payments = client.request(payment::All::default().limit(1)).unwrap();
+/// let payment = &payments.records()[0];
+///
+/// // All "operations" have transaction hashes, and a payment is a type of operation
+/// let hash = payment.transaction();
+///
+/// let payments = client.request(transaction::Payments::new(hash)).unwrap();
+///
+/// assert!(payments.records().len() > 0);
+/// assert_eq!(payments.records()[0].transaction(), hash);
 /// ```
 #[derive(Debug, Clone)]
 pub struct Payments {
@@ -266,24 +270,9 @@ impl Payments {
     /// ## Example
     ///
     /// ```
-    /// use stellar_client::sync::Client;
     /// use stellar_client::endpoint::transaction;
-    /// # use stellar_client::endpoint::Order;
     ///
-    /// let client = Client::horizon_test().unwrap();
-    /// #
-    /// # let transaction_ep   = transaction::All::default().limit(1);
-    /// # let txns             = client.request(transaction_ep).unwrap();
-    /// # let txn              = &txns.records()[0];
-    /// # let hash             = txn.hash();
-    /// # let endpoint = transaction::Payments::new(hash);
-    /// # let prev_page = client.request(endpoint).unwrap();
-    /// # let cursor = prev_page.next_cursor();
-    /// #
-    /// let endpoint = transaction::Payments::new(hash).cursor(cursor);
-    /// let payments = client.request(endpoint).unwrap();
-    /// #
-    /// # // Impossible to assert seeing as not all transactions have payments
+    /// let endpoint = transaction::Payments::new("ABC123").cursor("CURSOR");
     /// ```
     pub fn cursor(mut self, cursor: &str) -> Self {
         self.cursor = Some(cursor.to_string());
@@ -295,20 +284,9 @@ impl Payments {
     /// ## Example
     ///
     /// ```
-    /// use stellar_client::sync::Client;
     /// use stellar_client::endpoint::transaction;
     ///
-    /// let client = Client::horizon_test().unwrap();
-    /// #
-    /// # let transaction_ep   = transaction::All::default().limit(1);
-    /// # let txns             = client.request(transaction_ep).unwrap();
-    /// # let txn              = &txns.records()[0];
-    /// # let hash             = txn.hash();
-    /// #
-    /// let endpoint = transaction::Payments::new(hash).limit(1);
-    /// let records = client.request(endpoint).unwrap();
-    /// #
-    /// # // Impossible to assert seeing as not all transactions have payments
+    /// let endpoint = transaction::Payments::new("ABC123").limit(1);
     /// ```
     pub fn limit(mut self, limit: u32) -> Self {
         self.limit = Some(limit);
@@ -320,20 +298,9 @@ impl Payments {
     /// ## Example
     ///
     /// ```
-    /// use stellar_client::sync::Client;
     /// use stellar_client::endpoint::{transaction, Order};
     ///
-    /// let client = Client::horizon_test().unwrap();
-    /// #
-    /// # let transaction_ep   = transaction::All::default().limit(1);
-    /// # let txns             = client.request(transaction_ep).unwrap();
-    /// # let txn              = &txns.records()[0];
-    /// # let hash             = txn.hash();
-    /// #
-    /// let endpoint = transaction::Payments::new(hash).order(Order::Asc);
-    /// let records = client.request(endpoint).unwrap();
-    /// #
-    /// # // Impossible to assert seeing as not all transactions have payments
+    /// let endpoint = transaction::Payments::new("ABC123").order(Order::Asc);
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
@@ -398,6 +365,156 @@ mod transaction_payments_test {
             .limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/transactions/HASH123/payments");
+        assert_eq!(
+            req.uri().query(),
+            Some("cursor=CURSOR&order=desc&limit=123")
+        );
+    }
+}
+
+/// Returns the operations associated with a singular transactions.
+///
+/// <https://www.stellar.org/developers/horizon/reference/endpoints/operations-for-transaction.html>
+///
+/// ## Example
+///
+/// ```
+/// use stellar_client::sync::Client;
+/// use stellar_client::endpoint::{transaction, operation};
+///
+/// let client   = Client::horizon_test().unwrap();
+///
+/// // Grab an operation from the all operations end point
+/// let operations = client.request(operation::All::default().limit(1)).unwrap();
+/// let operation = &operations.records()[0];
+///
+/// // All "operations" have transaction hashes.
+/// let hash = operation.transaction();
+///
+/// let operations = client.request(transaction::Operations::new(hash)).unwrap();
+///
+/// assert!(operations.records().len() > 0);
+/// assert_eq!(operations.records()[0].transaction(), hash);
+/// ```
+#[derive(Debug, Clone)]
+pub struct Operations {
+    hash: String,
+    cursor: Option<String>,
+    order: Option<Order>,
+    limit: Option<u32>,
+}
+
+impl Operations {
+    /// Creates a new struct representing a request to the payments endpoint
+    pub fn new(hash: &str) -> Operations {
+        Operations {
+            hash: hash.to_string(),
+            cursor: None,
+            order: None,
+            limit: None,
+        }
+    }
+
+    /// Starts the page of results at a given cursor
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::endpoint::transaction;
+    ///
+    /// let endpoint = transaction::Operations::new("ABC123").cursor("CURSOR");
+    /// ```
+    pub fn cursor(mut self, cursor: &str) -> Self {
+        self.cursor = Some(cursor.to_string());
+        self
+    }
+
+    /// Fetches all records with a given limit
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::endpoint::transaction;
+    ///
+    /// let endpoint = transaction::Operations::new("ABC123").limit(1);
+    /// ```
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Fetches all records in a set order, either ascending or descending.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use stellar_client::endpoint::{transaction, Order};
+    ///
+    /// let endpoint = transaction::Operations::new("ABC123").order(Order::Asc);
+    /// ```
+    pub fn order(mut self, order: Order) -> Self {
+        self.order = Some(order);
+        self
+    }
+
+    fn has_query(&self) -> bool {
+        self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
+    }
+}
+
+impl IntoRequest for Operations {
+    type Response = Records<Operation>;
+
+    fn into_request(self, host: &str) -> Result<Request<Body>> {
+        let mut uri = format!("{}/transactions/{}/operations", host, self.hash);
+        if self.has_query() {
+            uri.push_str("?");
+
+            if let Some(cursor) = self.cursor {
+                uri.push_str(&format!("cursor={}&", cursor));
+            }
+
+            if let Some(order) = self.order {
+                uri.push_str(&format!("order={}&", order.to_string()));
+            }
+
+            if let Some(limit) = self.limit {
+                uri.push_str(&format!("limit={}", limit));
+            }
+        }
+
+        let uri = Uri::from_str(&uri)?;
+        let request = Request::get(uri).body(Body::None)?;
+        Ok(request)
+    }
+}
+
+impl Cursor for Operations {
+    fn cursor(self, cursor: &str) -> Operations {
+        self.cursor(cursor)
+    }
+}
+
+#[cfg(test)]
+mod transaction_operations_test {
+    use super::*;
+
+    #[test]
+    fn it_leaves_off_the_params_if_not_specified() {
+        let ep = Operations::new("HASH123");
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/transactions/HASH123/operations");
+        assert_eq!(req.uri().query(), None);
+    }
+
+    #[test]
+    fn it_puts_the_query_params_on_the_uri() {
+        let ep = Operations::new("HASH123")
+            .cursor("CURSOR")
+            .order(Order::Desc)
+            .limit(123);
+        let req = ep.into_request("https://www.google.com").unwrap();
+        assert_eq!(req.uri().path(), "/transactions/HASH123/operations");
         assert_eq!(
             req.uri().query(),
             Some("cursor=CURSOR&order=desc&limit=123")


### PR DESCRIPTION
Adds the implementation for querying operations for a given transaction.
Also refactors the payment doctests to only run actual horizon queries
in a single example on the struct.

fixes #73 

### Is there a GIF that reflects how this work made you feel?
![hrmph](https://user-images.githubusercontent.com/2043529/38509016-8daff9be-3bd5-11e8-8c6e-75f3ed77971e.gif)
