### PR TITLE
Rename function in Cursor

### DIFF
--- a/cli/src/cursor.rs
+++ b/cli/src/cursor.rs
@@ -19,7 +19,7 @@ where
     C: Cursor,
 {
     match arg.value_of(ARG_NAME) {
-        Some(cur) => endpoint.cursor(cur),
+        Some(cur) => endpoint.with_cursor(cur),
         None => endpoint,
     }
 }
@@ -28,14 +28,18 @@ where
 mod tests {
     use super::*;
 
-    struct TestCurse {
+    struct TestCursor {
         cursor: Option<String>,
     }
 
-    impl Cursor for TestCurse {
-        fn cursor(mut self, cursor: &str) -> TestCurse {
+    impl Cursor for TestCursor {
+        fn with_cursor(mut self, cursor: &str) -> TestCursor {
             self.cursor = Some(cursor.to_owned());
             self
+        }
+
+        fn cursor(&self) -> Option<&str> {
+            self.cursor.as_ref().map(|s| &**s)
         }
     }
 
@@ -51,16 +55,16 @@ mod tests {
     #[test]
     fn it_sets_the_cursor_if_provided() {
         let arg_matches = get_matches(vec!["test", "--cursor", "123abc"]);
-        let cursor = TestCurse { cursor: None };
+        let cursor = TestCursor { cursor: None };
         let cursor = assign_from_arg(&arg_matches, cursor);
-        assert_eq!(cursor.cursor, Some("123abc".to_owned()));
+        assert_eq!(cursor.cursor(), Some("123abc"));
     }
 
     #[test]
     fn it_defaults_to_none() {
         let arg_matches = get_matches(vec!["test"]);
-        let cursor = TestCurse { cursor: None };
+        let cursor = TestCursor { cursor: None };
         let cursor = assign_from_arg(&arg_matches, cursor);
-        assert_eq!(cursor.cursor, None);
+        assert_eq!(cursor.cursor(), None);
     }
 }

--- a/client/src/client/sync/iter.rs
+++ b/client/src/client/sync/iter.rs
@@ -55,7 +55,7 @@ where
         self.next = 0;
         let mut endpoint = self.endpoint.clone();
         if let Some(ref records) = self.records {
-            endpoint = endpoint.cursor(records.next_cursor());
+            endpoint = endpoint.with_cursor(records.next_cursor());
         }
         self.records = Some(self.client.request(endpoint)?);
         Ok(())

--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -270,7 +270,7 @@ mod transactions_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Transactions::new("abc123")
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .order(Order::Desc)
             .limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
@@ -421,7 +421,7 @@ mod effects_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Effects::new("abc123")
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .order(Order::Asc)
             .limit(123);
         let req = ep.into_request("https://horizon-testnet.stellar.org")
@@ -562,7 +562,7 @@ mod ledger_operations_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Operations::new("abc123")
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
@@ -713,7 +713,7 @@ mod payments_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Payments::new("abc123")
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .order(Order::Desc)
             .limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();

--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -171,7 +171,7 @@ mod all_assets_tests {
         let ep = All::default()
             .asset_code("CODE")
             .asset_issuer("ISSUER")
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();

--- a/client/src/endpoint/cursor.rs
+++ b/client/src/endpoint/cursor.rs
@@ -5,11 +5,19 @@
 /// ```
 /// use stellar_client::endpoint::{Cursor, transaction};
 ///
-/// let txns = transaction::All::default().cursor("CURSOR");
+/// let txns = transaction::All::default();
+/// assert_eq!(txns.cursor(), None);
+///
+/// let txns = txns.with_cursor("CURSOR");
+/// assert_eq!(txns.cursor(), Some("CURSOR"));
+///
 /// ```
 pub trait Cursor {
     /// Sets a cursor on the struct and returns an owned version.
-    fn cursor(self, cursor: &str) -> Self;
+    fn with_cursor(self, cursor: &str) -> Self;
+
+    /// Returns the cursor that has been set, if it has been set.
+    fn cursor(&self) -> Option<&str>;
 }
 
 #[cfg(test)]
@@ -23,8 +31,8 @@ mod test {
             cursor: Option<String>,
         }
 
-        let foo = Foo { cursor: None };
-        let foo = foo.cursor("CURSOR");
+        let foo = Foo { cursor: None }.with_cursor("CURSOR");
         assert_eq!(foo.cursor, Some("CURSOR".to_string()));
+        assert_eq!(foo.cursor(), Some("CURSOR"));
     }
 }

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -115,7 +115,7 @@ mod all_ledgers_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
@@ -320,7 +320,7 @@ mod ledger_payments_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Payments::new(123)
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
@@ -460,7 +460,7 @@ mod ledger_transactions_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Transactions::new(123)
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
@@ -602,7 +602,7 @@ mod ledger_effects_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Effects::new(123)
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
@@ -744,7 +744,7 @@ mod ledger_operations_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Operations::new(123)
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();

--- a/client/src/endpoint/operation.rs
+++ b/client/src/endpoint/operation.rs
@@ -109,7 +109,7 @@ mod all_operationss_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -117,7 +117,7 @@ mod all_transactions_test {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .order(Order::Desc)
             .limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
@@ -307,7 +307,7 @@ mod transaction_payments_test {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Payments::new("HASH123")
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .order(Order::Desc)
             .limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
@@ -437,7 +437,7 @@ mod transaction_operations_test {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Operations::new("HASH123")
-            .cursor("CURSOR")
+            .with_cursor("CURSOR")
             .order(Order::Desc)
             .limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -19,9 +19,15 @@ pub fn cursor(input: TokenStream) -> TokenStream {
         {
             let code = quote! {
                 impl Cursor for #name {
-                    fn cursor(mut self, cursor: &str) -> #name {
+                    fn with_cursor(mut self, cursor: &str) -> #name {
                         self.cursor = Some(cursor.to_string());
                         self
+                    }
+
+                    fn cursor(&self) -> Option<&str> {
+                        // Take the cursor as a ref, then map the string to a slice. Needs
+                        // two derefs to deref to String then to str then return reference
+                        self.cursor.as_ref().map(|s| &**s)
                     }
                 }
             };


### PR DESCRIPTION
Renames the builder function to `with_cursor` to make it more clear that
it's a builder. This also allows me to add a getter function of
`cursor()`.

### Is there a GIF that reflects how this work made you feel?
![up-down-south-in-and-out](https://user-images.githubusercontent.com/2043529/38580922-1b5d48e4-3cc0-11e8-8c58-e438930c1463.gif)
