### PR TITLE
Implement custom derive for limit

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,5 +1,5 @@
 use clap::ArgMatches;
-use stellar_client::{sync, endpoint::account, error::Result, sync::Client};
+use stellar_client::{sync, endpoint::{account, Limit}, error::Result, sync::Client};
 use super::{cursor, ordering, pager::Pager};
 
 pub fn details<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
@@ -20,7 +20,7 @@ pub fn transactions<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let endpoint = {
         let endpoint = account::Transactions::new(id)
             .order(ordering::from_arg(matches))
-            .limit(pager.horizon_page_limit() as u32);
+            .with_limit(pager.horizon_page_limit() as u32);
         cursor::assign_from_arg(matches, endpoint)
     };
     let iter = sync::Iter::new(&client, endpoint);

--- a/cli/src/assets.rs
+++ b/cli/src/assets.rs
@@ -1,4 +1,4 @@
-use stellar_client::{endpoint::asset, error::Result, sync::{self, Client}};
+use stellar_client::{endpoint::{asset, Limit}, error::Result, sync::{self, Client}};
 use clap::ArgMatches;
 use super::{cursor, ordering, pager::Pager};
 
@@ -10,7 +10,7 @@ pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let endpoint = {
         let mut endpoint = asset::All::default()
             .order(ordering::from_arg(matches))
-            .limit(pager.horizon_page_limit() as u32);
+            .with_limit(pager.horizon_page_limit() as u32);
 
         if let Some(code) = matches.value_of("code") {
             endpoint = endpoint.asset_code(code);

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -1,4 +1,4 @@
-use stellar_client::{endpoint::transaction, error::Result, sync::{self, Client}};
+use stellar_client::{endpoint::{transaction, Limit}, error::Result, sync::{self, Client}};
 use clap::ArgMatches;
 use super::{cursor, ordering, pager::Pager};
 
@@ -7,7 +7,7 @@ pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     let endpoint = {
         let endpoint = transaction::All::default()
             .order(ordering::from_arg(matches))
-            .limit(pager.horizon_page_limit() as u32);
+            .with_limit(pager.horizon_page_limit() as u32);
         cursor::assign_from_arg(matches, endpoint)
     };
     let iter = sync::Iter::new(&client, endpoint);

--- a/client/src/client/sync/iter.rs
+++ b/client/src/client/sync/iter.rs
@@ -10,11 +10,11 @@ use error::Result;
 ///
 /// ```
 /// use stellar_client::{
-///     endpoint::asset,
+///     endpoint::{asset, Limit},
 ///     sync::{Client, Iter},
 /// };
 /// let client = Client::horizon_test().unwrap();
-/// let endpoint = asset::All::default().limit(3);
+/// let endpoint = asset::All::default().with_limit(3);
 /// let iter = Iter::new(&client, endpoint);
 /// assert_eq!(iter.take(10).count(), 10);
 /// ```
@@ -104,13 +104,13 @@ where
 #[cfg(test)]
 mod iterator_tests {
     use super::*;
-    use endpoint::{account, asset};
+    use endpoint::{account, asset, Limit};
     use stellar_resources::Transaction;
 
     #[test]
     fn it_can_iterate_through_records() {
         let client = Client::horizon_test().unwrap();
-        let endpoint = asset::All::default().limit(3);
+        let endpoint = asset::All::default().with_limit(3);
         let iter = Iter::new(&client, endpoint);
         assert!(iter.take(10).count() > 3);
     }

--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Asset;
-use super::{Body, Cursor, IntoRequest, Order, Records};
+use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all assets end point for the stellar horizon server. The endpoint
@@ -22,7 +22,7 @@ use http::{Request, Uri};
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Clone, Cursor)]
+#[derive(Debug, Default, Clone, Cursor, Limit)]
 pub struct All {
     code: Option<String>,
     issuer: Option<String>,
@@ -94,25 +94,6 @@ impl All {
         self
     }
 
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::sync::Client;
-    /// use stellar_client::endpoint::asset;
-    ///
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = asset::All::default().limit(3);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert_eq!(records.records().len(), 3);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
-        self
-    }
-
     fn has_query(&self) -> bool {
         self.code.is_some() || self.issuer.is_some() || self.order.is_some()
             || self.cursor.is_some() || self.limit.is_some()
@@ -172,7 +153,7 @@ mod all_assets_tests {
             .asset_code("CODE")
             .asset_issuer("ISSUER")
             .with_cursor("CURSOR")
-            .limit(123)
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/assets");

--- a/client/src/endpoint/effect.rs
+++ b/client/src/endpoint/effect.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Effect;
-use super::{Body, IntoRequest, Order, Records};
+use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 pub use super::account::Effects as ForAccount;
 pub use super::ledger::Effects as ForLedger;
@@ -23,7 +23,7 @@ pub use super::ledger::Effects as ForLedger;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Cursor, Limit)]
 pub struct All {
     cursor: Option<String>,
     order: Option<Order>,
@@ -47,51 +47,6 @@ impl All {
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
-        self
-    }
-
-    /// Starts the page of results at a given cursor
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use stellar_client::sync::Client;
-    /// # use stellar_client::endpoint::effect;
-    /// #
-    /// let client      = Client::horizon_test().unwrap();
-    /// #
-    /// # // grab first page and extract cursor
-    /// # let endpoint      = effect::All::default().limit(1);
-    /// # let first_page    = client.request(endpoint).unwrap();
-    /// # let cursor        = first_page.next_cursor();
-    /// #
-    /// let endpoint    = effect::All::default().cursor(cursor).limit(1);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert!(records.records().len() > 0);
-    /// # assert_ne!(records.next_cursor(), cursor);
-    /// ```
-    pub fn cursor(mut self, cursor: &str) -> Self {
-        self.cursor = Some(cursor.to_string());
-        self
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use stellar_client::sync::Client;
-    /// # use stellar_client::endpoint::effect;
-    /// #
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = effect::All::default().limit(3);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert_eq!(records.records().len(), 3);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
         self
     }
 
@@ -143,8 +98,8 @@ mod all_effects_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
-            .cursor("CURSOR")
-            .limit(123)
+            .with_cursor("CURSOR")
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/effects");

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::{Effect, Ledger, Operation, Transaction};
-use super::{Body, Cursor, IntoRequest, Order, Records};
+use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all ledgers end point for the stellar horizon server. The endpoint
@@ -21,7 +21,7 @@ use http::{Request, Uri};
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Clone, Cursor)]
+#[derive(Debug, Default, Clone, Cursor, Limit)]
 pub struct All {
     cursor: Option<String>,
     order: Option<Order>,
@@ -45,25 +45,6 @@ impl All {
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
-        self
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use stellar_client::sync::Client;
-    /// # use stellar_client::endpoint::ledger;
-    /// #
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = ledger::All::default().limit(3);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert_eq!(records.records().len(), 3);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
         self
     }
 
@@ -116,7 +97,7 @@ mod all_ledgers_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
             .with_cursor("CURSOR")
-            .limit(123)
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers");
@@ -215,7 +196,7 @@ mod ledger_details_tests {
 ///
 /// assert!(payments.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor)]
+#[derive(Debug, Clone, Cursor, Limit)]
 pub struct Payments {
     sequence: u32,
     cursor: Option<String>,
@@ -253,22 +234,6 @@ impl Payments {
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
-        self
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::ledger;
-    ///
-    /// # // Not making requests seeing as the main documentation has it.
-    /// # // This is just to document the usage and conserve hits to horizon.
-    /// let endpoint = ledger::Payments::new(123).limit(15);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
         self
     }
 
@@ -321,7 +286,7 @@ mod ledger_payments_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Payments::new(123)
             .with_cursor("CURSOR")
-            .limit(123)
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers/123/payments");
@@ -340,12 +305,12 @@ mod ledger_payments_tests {
 /// ## Example
 /// ```
 /// use stellar_client::sync::Client;
-/// use stellar_client::endpoint::{ledger, transaction};
+/// use stellar_client::endpoint::{ledger, transaction, Limit};
 ///
 /// let client   = Client::horizon_test().unwrap();
 ///
 /// // Grab transactions and associated ledger to ensure a ledger sequence with transactions
-/// let txns = client.request(transaction::All::default().limit(1)).unwrap();
+/// let txns = client.request(transaction::All::default().with_limit(1)).unwrap();
 /// let txn = &txns.records()[0];
 /// let sequence = txn.ledger();
 ///
@@ -355,7 +320,7 @@ mod ledger_payments_tests {
 ///
 /// assert!(ledger_txns.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor)]
+#[derive(Debug, Clone, Cursor, Limit)]
 pub struct Transactions {
     sequence: u32,
     cursor: Option<String>,
@@ -393,22 +358,6 @@ impl Transactions {
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
-        self
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::ledger;
-    ///
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = ledger::Transactions::new(123).limit(15);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
         self
     }
 
@@ -461,7 +410,7 @@ mod ledger_transactions_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Transactions::new(123)
             .with_cursor("CURSOR")
-            .limit(123)
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers/123/transactions");
@@ -480,14 +429,14 @@ mod ledger_transactions_tests {
 /// ## Example
 /// ```
 /// use stellar_client::sync::Client;
-/// use stellar_client::endpoint::{ledger, transaction};
+/// use stellar_client::endpoint::{ledger, transaction, Limit};
 ///
 /// let client   = Client::horizon_test().unwrap();
 ///
 /// // Grab transactions and associated ledger to ensure a ledger sequence with transactions.
 /// // We seek transactions because effects have no references to a ledger and a ledger with
 /// // transactions by definition has effects.
-/// let txns = client.request(transaction::All::default().limit(1)).unwrap();
+/// let txns = client.request(transaction::All::default().with_limit(1)).unwrap();
 /// let txn = &txns.records()[0];
 /// let sequence = txn.ledger();
 ///
@@ -497,7 +446,7 @@ mod ledger_transactions_tests {
 ///
 /// assert!(ledger_effects.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor)]
+#[derive(Debug, Clone, Cursor, Limit)]
 pub struct Effects {
     sequence: u32,
     cursor: Option<String>,
@@ -535,22 +484,6 @@ impl Effects {
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
-        self
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::ledger;
-    ///
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = ledger::Effects::new(123).limit(15);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
         self
     }
 
@@ -603,7 +536,7 @@ mod ledger_effects_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Effects::new(123)
             .with_cursor("CURSOR")
-            .limit(123)
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers/123/effects");
@@ -622,14 +555,14 @@ mod ledger_effects_tests {
 /// ## Example
 /// ```
 /// use stellar_client::sync::Client;
-/// use stellar_client::endpoint::{ledger, transaction};
+/// use stellar_client::endpoint::{ledger, transaction, Limit};
 ///
 /// let client   = Client::horizon_test().unwrap();
 ///
 /// // Grab transactions and associated ledger to ensure a ledger sequence with transactions.
 /// // We seek transactions because operations have no references to a ledger and a ledger with
 /// // transactions by definition has operations.
-/// let txns = client.request(transaction::All::default().limit(1)).unwrap();
+/// let txns = client.request(transaction::All::default().with_limit(1)).unwrap();
 /// let txn = &txns.records()[0];
 /// let sequence = txn.ledger();
 ///
@@ -639,7 +572,7 @@ mod ledger_effects_tests {
 ///
 /// assert!(ledger_operations.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor)]
+#[derive(Debug, Clone, Cursor, Limit)]
 pub struct Operations {
     sequence: u32,
     cursor: Option<String>,
@@ -677,22 +610,6 @@ impl Operations {
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
-        self
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::ledger;
-    ///
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = ledger::Operations::new(123).limit(15);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
         self
     }
 
@@ -745,7 +662,7 @@ mod ledger_operations_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Operations::new(123)
             .with_cursor("CURSOR")
-            .limit(123)
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers/123/operations");

--- a/client/src/endpoint/limit.rs
+++ b/client/src/endpoint/limit.rs
@@ -1,0 +1,33 @@
+/// Declares that this endpoint has a limit and can have it set.
+///
+/// ## Example
+///
+/// ```
+/// use stellar_client::endpoint::{Limit, transaction};
+///
+/// let txns = transaction::All::default().with_limit(2);
+/// ```
+pub trait Limit {
+    /// Sets a limit on the struct and returns an owned version.
+    fn with_limit(self, limit: u32) -> Self;
+
+    /// Returns the limit or None.
+    fn limit(&self) -> Option<u32>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_can_be_derived() {
+        #[derive(Limit)]
+        struct Foo {
+            limit: Option<u32>,
+        }
+
+        let foo = Foo { limit: None };
+        let foo = foo.with_limit(7);
+        assert_eq!(foo.limit(), Some(7));
+    }
+}

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -28,11 +28,13 @@ pub mod ledger;
 pub mod operation;
 pub mod payment;
 pub mod transaction;
-mod records;
 mod cursor;
+mod limit;
+mod records;
 
-pub use self::records::Records;
 pub use self::cursor::Cursor;
+pub use self::limit::Limit;
+pub use self::records::Records;
 
 /// Represents the body of a request to an IntoRequest.
 #[derive(Debug)]

--- a/client/src/endpoint/operation.rs
+++ b/client/src/endpoint/operation.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Operation;
-use super::{Body, Cursor, IntoRequest, Order, Records};
+use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 pub use super::account::Operations as ForAccount;
@@ -25,7 +25,7 @@ pub use super::transaction::Operations as ForTransaction;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Clone, Cursor)]
+#[derive(Debug, Default, Clone, Cursor, Limit)]
 pub struct All {
     cursor: Option<String>,
     order: Option<Order>,
@@ -44,20 +44,6 @@ impl All {
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
-        self
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::operation;
-    ///
-    /// let endpoint = operation::All::default().limit(3);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
         self
     }
 
@@ -110,7 +96,7 @@ mod all_operationss_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
             .with_cursor("CURSOR")
-            .limit(123)
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/operations");
@@ -130,13 +116,13 @@ mod all_operationss_tests {
 ///
 /// ```
 /// use stellar_client::sync::Client;
-/// use stellar_client::endpoint::operation;
+/// use stellar_client::endpoint::{operation, Limit};
 ///
 /// let client = Client::horizon_test().unwrap();
 ///
 /// // Grab an operation so that we know that we can request one from
 /// // horizon that actually exists.
-/// let all = operation::All::default().limit(1);
+/// let all = operation::All::default().with_limit(1);
 /// let all = client.request(all).unwrap();
 ///
 /// let operation_id = all.records()[0].id();

--- a/client/src/endpoint/payment.rs
+++ b/client/src/endpoint/payment.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Operation;
-use super::{Body, IntoRequest, Order, Records};
+use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 pub use super::transaction::Payments as ForTransaction;
@@ -25,7 +25,7 @@ pub use super::account::Payments as ForAccount;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Cursor, Limit)]
 pub struct All {
     cursor: Option<String>,
     order: Option<Order>,
@@ -49,51 +49,6 @@ impl All {
     /// ```
     pub fn order(mut self, order: Order) -> Self {
         self.order = Some(order);
-        self
-    }
-
-    /// Starts the page of results at a given cursor
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use stellar_client::sync::Client;
-    /// # use stellar_client::endpoint::payment;
-    /// #
-    /// let client      = Client::horizon_test().unwrap();
-    /// #
-    /// # // grab first page and extract cursor
-    /// # let endpoint      = payment::All::default().limit(1);
-    /// # let first_page    = client.request(endpoint).unwrap();
-    /// # let cursor        = first_page.next_cursor();
-    /// #
-    /// let endpoint    = payment::All::default().cursor(cursor);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert!(records.records().len() > 0);
-    /// # assert_ne!(records.next_cursor(), cursor);
-    /// ```
-    pub fn cursor(mut self, cursor: &str) -> Self {
-        self.cursor = Some(cursor.to_string());
-        self
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use stellar_client::sync::Client;
-    /// # use stellar_client::endpoint::payment;
-    /// #
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = payment::All::default().limit(3);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert_eq!(records.records().len(), 3);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
         self
     }
 
@@ -145,8 +100,8 @@ mod all_payments_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
-            .cursor("CURSOR")
-            .limit(123)
+            .with_cursor("CURSOR")
+            .with_limit(123)
             .order(Order::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/payments");

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::{Operation, Transaction};
-use super::{Body, Cursor, IntoRequest, Order, Records};
+use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 pub use super::account::Transactions as ForAccount;
 pub use super::ledger::Transactions as ForLedger;
@@ -24,7 +24,7 @@ pub use super::ledger::Transactions as ForLedger;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Clone, Cursor)]
+#[derive(Debug, Default, Clone, Cursor, Limit)]
 pub struct All {
     cursor: Option<String>,
     order: Option<Order>,
@@ -32,25 +32,6 @@ pub struct All {
 }
 
 impl All {
-    /// Fetches all records with a given limit
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::sync::Client;
-    /// use stellar_client::endpoint::transaction;
-    ///
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = transaction::All::default().limit(1);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert_eq!(records.records().len(), 1);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
-        self
-    }
-
     /// Fetches all records in a set order, either ascending or descending.
     ///
     /// ## Example
@@ -119,7 +100,7 @@ mod all_transactions_test {
         let ep = All::default()
             .with_cursor("CURSOR")
             .order(Order::Desc)
-            .limit(123);
+            .with_limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/transactions");
         assert_eq!(
@@ -137,10 +118,10 @@ mod all_transactions_test {
 ///
 /// ```
 /// use stellar_client::sync::Client;
-/// use stellar_client::endpoint::transaction;
+/// use stellar_client::endpoint::{transaction, Limit};
 ///
 /// let client   = Client::horizon_test().unwrap();
-/// # let transaction_ep   = transaction::All::default().limit(1);
+/// # let transaction_ep   = transaction::All::default().with_limit(1);
 /// # let txns             = client.request(transaction_ep).unwrap();
 /// # let txn              = &txns.records()[0];
 /// # let hash             = txn.hash();
@@ -197,12 +178,12 @@ mod transaction_details_tests {
 ///
 /// ```
 /// use stellar_client::sync::Client;
-/// use stellar_client::endpoint::{transaction, payment};
+/// use stellar_client::endpoint::{transaction, payment, Limit};
 ///
 /// let client   = Client::horizon_test().unwrap();
 ///
 /// // Grab a payment from the all payments end point
-/// let payments = client.request(payment::All::default().limit(1)).unwrap();
+/// let payments = client.request(payment::All::default().with_limit(1)).unwrap();
 /// let payment = &payments.records()[0];
 ///
 /// // All "operations" have transaction hashes, and a payment is a type of operation
@@ -213,7 +194,7 @@ mod transaction_details_tests {
 /// assert!(payments.records().len() > 0);
 /// assert_eq!(payments.records()[0].transaction(), hash);
 /// ```
-#[derive(Debug, Clone, Cursor)]
+#[derive(Debug, Clone, Cursor, Limit)]
 pub struct Payments {
     hash: String,
     cursor: Option<String>,
@@ -230,20 +211,6 @@ impl Payments {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records with a given limit
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::transaction;
-    ///
-    /// let endpoint = transaction::Payments::new("ABC123").limit(1);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
-        self
     }
 
     /// Fetches all records in a set order, either ascending or descending.
@@ -309,7 +276,7 @@ mod transaction_payments_test {
         let ep = Payments::new("HASH123")
             .with_cursor("CURSOR")
             .order(Order::Desc)
-            .limit(123);
+            .with_limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/transactions/HASH123/payments");
         assert_eq!(
@@ -327,12 +294,12 @@ mod transaction_payments_test {
 ///
 /// ```
 /// use stellar_client::sync::Client;
-/// use stellar_client::endpoint::{transaction, operation};
+/// use stellar_client::endpoint::{transaction, operation, Limit};
 ///
 /// let client   = Client::horizon_test().unwrap();
 ///
 /// // Grab an operation from the all operations end point
-/// let operations = client.request(operation::All::default().limit(1)).unwrap();
+/// let operations = client.request(operation::All::default().with_limit(1)).unwrap();
 /// let operation = &operations.records()[0];
 ///
 /// // All "operations" have transaction hashes.
@@ -343,7 +310,7 @@ mod transaction_payments_test {
 /// assert!(operations.records().len() > 0);
 /// assert_eq!(operations.records()[0].transaction(), hash);
 /// ```
-#[derive(Debug, Clone, Cursor)]
+#[derive(Debug, Clone, Cursor, Limit)]
 pub struct Operations {
     hash: String,
     cursor: Option<String>,
@@ -360,20 +327,6 @@ impl Operations {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records with a given limit
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::transaction;
-    ///
-    /// let endpoint = transaction::Operations::new("ABC123").limit(1);
-    /// ```
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
-        self
     }
 
     /// Fetches all records in a set order, either ascending or descending.
@@ -439,7 +392,7 @@ mod transaction_operations_test {
         let ep = Operations::new("HASH123")
             .with_cursor("CURSOR")
             .order(Order::Desc)
-            .limit(123);
+            .with_limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/transactions/HASH123/operations");
         assert_eq!(

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -41,3 +41,35 @@ pub fn cursor(input: TokenStream) -> TokenStream {
         panic!("#[derive(Cursor)] is only valid for structs")
     }
 }
+
+#[proc_macro_derive(Limit)]
+pub fn limit(input: TokenStream) -> TokenStream {
+    // Parse the string representation
+    let ast: DeriveInput = syn::parse(input).unwrap();
+    let name = &ast.ident;
+
+    if let Data::Struct(data) = ast.data {
+        if data.fields
+            .iter()
+            .any(|f| f.ident == Some(Ident::from("limit")))
+        {
+            let code = quote! {
+                impl Limit for #name {
+                    fn with_limit(mut self, limit: u32) -> #name {
+                        self.limit = Some(limit);
+                        self
+                    }
+
+                    fn limit(&self) -> Option<u32> {
+                        self.limit
+                    }
+                }
+            };
+            code.into()
+        } else {
+            panic!("#[derive(Limit)] is only valid for structs that define `limit: Option<u32>`")
+        }
+    } else {
+        panic!("#[derive(Limit)] is only valid for structs")
+    }
+}


### PR DESCRIPTION
This PR is modeled after the cursor derive built out for endpoints.  The
overarching goal of these extractions is to reduce the code and overhead
associated with adding new endpoints tot he client.

resolves #136 

