### PR TITLE
Address more clippy warnings

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -2,7 +2,7 @@ use clap::ArgMatches;
 use stellar_client::{sync, endpoint::{account, Limit}, error::Result, sync::Client};
 use super::{cursor, ordering, pager::Pager};
 
-pub fn details<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
+pub fn details(client: &Client, matches: &ArgMatches) -> Result<()> {
     let id = matches.value_of("ID").expect("ID is required");
     let endpoint = account::Details::new(id);
     let account = client.request(endpoint)?;
@@ -13,7 +13,7 @@ pub fn details<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
     Ok(())
 }
 
-pub fn transactions<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
+pub fn transactions(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
 
     let id = matches.value_of("ID").expect("ID is required");
@@ -31,7 +31,7 @@ pub fn transactions<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
             println!("ID:             {}", txn.id());
             println!("source account: {}", txn.source_account());
             println!("created at:     {}", txn.created_at());
-            println!("");
+            println!();
         }
         Err(err) => res = Err(err),
     });

--- a/cli/src/assets.rs
+++ b/cli/src/assets.rs
@@ -4,7 +4,7 @@ use super::{cursor, ordering, pager::Pager};
 
 /// Using a client and the arguments from the command line, iterates over the results
 /// and displays them to the end user.
-pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
+pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
 
     let endpoint = {
@@ -37,7 +37,7 @@ pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
             if asset.is_auth_revocable() {
                 println!("  auth is revocable");
             }
-            println!("");
+            println!();
         }
         Err(err) => res = Err(err),
     });

--- a/cli/src/cursor.rs
+++ b/cli/src/cursor.rs
@@ -14,7 +14,7 @@ pub fn add<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 /// Parses the argument matches and returns the order to use.
-pub fn assign_from_arg<'a, C>(arg: &'a ArgMatches, endpoint: C) -> C
+pub fn assign_from_arg<C>(arg: &ArgMatches, endpoint: C) -> C
 where
     C: Cursor,
 {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -121,16 +121,16 @@ fn main() {
     // Master match block. All subcommands need to be captured here.
     let result = match matches.subcommand() {
         ("account", Some(sub_m)) => match sub_m.subcommand() {
-            ("details", Some(sub_m)) => account::details(client, sub_m),
-            ("transactions", Some(sub_m)) => account::transactions(client, sub_m),
+            ("details", Some(sub_m)) => account::details(&client, sub_m),
+            ("transactions", Some(sub_m)) => account::transactions(&client, sub_m),
             _ => return print_help_and_exit(),
         },
         ("transactions", Some(sub_m)) => match sub_m.subcommand() {
-            ("all", Some(sub_m)) => transactions::all(client, sub_m),
+            ("all", Some(sub_m)) => transactions::all(&client, sub_m),
             _ => return print_help_and_exit(),
         },
         ("assets", Some(sub_m)) => match sub_m.subcommand() {
-            ("all", Some(m)) => assets::all(client, m),
+            ("all", Some(m)) => assets::all(&client, m),
             _ => return print_help_and_exit(),
         },
         _ => return print_help_and_exit(),

--- a/cli/src/ordering.rs
+++ b/cli/src/ordering.rs
@@ -19,7 +19,7 @@ pub fn add<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 /// Parses the argument matches and returns the order to use.
-pub fn from_arg<'a>(arg: &'a ArgMatches) -> Order {
+pub fn from_arg(arg: &ArgMatches) -> Order {
     match arg.value_of(ARG_NAME) {
         Some(s) if s == ASC => Asc,
         Some(s) if s == DESC => Desc,

--- a/cli/src/pager.rs
+++ b/cli/src/pager.rs
@@ -35,7 +35,7 @@ impl Pager {
             .map_err(|_| String::from("Page size must be a positive integer"))
     }
 
-    pub fn from_arg<'a>(arg: &'a ArgMatches) -> Pager {
+    pub fn from_arg(arg: &ArgMatches) -> Pager {
         if let Some(size) = arg.value_of("page-size") {
             Pager {
                 size: PageSize::Size(usize::from_str(&size).unwrap_or(10)),
@@ -86,7 +86,7 @@ impl Pager {
         println!("-- press q to quit --");
         let mut input = String::new();
         match ::std::io::stdin().read_line(&mut input) {
-            Ok(_) => !input.starts_with("q"),
+            Ok(_) => !input.starts_with('q'),
             _ => false,
         }
     }

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -2,7 +2,7 @@ use stellar_client::{endpoint::{transaction, Limit}, error::Result, sync::{self,
 use clap::ArgMatches;
 use super::{cursor, ordering, pager::Pager};
 
-pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
+pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
     let endpoint = {
         let endpoint = transaction::All::default()
@@ -18,7 +18,7 @@ pub fn all<'a>(client: Client, matches: &'a ArgMatches) -> Result<()> {
             println!("ID:             {}", txn.id());
             println!("source account: {}", txn.source_account());
             println!("created at:     {}", txn.created_at());
-            println!("");
+            println!();
         }
         Err(err) => res = Err(err),
     });

--- a/client/src/client/sync/iter.rs
+++ b/client/src/client/sync/iter.rs
@@ -85,7 +85,7 @@ where
         match self.try_next_page() {
             Ok(()) => {
                 if let Some(ref records) = self.records {
-                    if records.records().len() > 0 {
+                    if !records.records().is_empty() {
                         let val = records.records()[self.next].clone();
                         self.next += 1;
                         return Some(Ok(val));

--- a/client/src/client/sync/mod.rs
+++ b/client/src/client/sync/mod.rs
@@ -134,7 +134,7 @@ impl Client {
         E: IntoRequest,
     {
         let request = endpoint.into_request(&self.uri())?;
-        let request = Self::http_to_reqwest(request);
+        let request = Self::http_to_reqwest(&request);
         let response = self.inner.execute(request)?;
         if response.status().is_success() {
             let resp: E::Response = serde_json::from_reader(response)?;
@@ -147,7 +147,7 @@ impl Client {
         }
     }
 
-    fn http_to_reqwest<T>(request: http::Request<T>) -> reqwest::Request {
+    fn http_to_reqwest<T>(request: &http::Request<T>) -> reqwest::Request {
         use http::method::Method;
         let method = match *request.method() {
             Method::GET => reqwest::Method::Get,

--- a/client/src/endpoint/records.rs
+++ b/client/src/endpoint/records.rs
@@ -89,7 +89,7 @@ impl Href {
         // Any error should just result in an empty string cursor
         if let Ok(uri) = self.href.parse::<http::Uri>() {
             if let Some(queries) = uri.query() {
-                if let Some(query) = queries.split("&").find(|q| q.starts_with("cursor=")) {
+                if let Some(query) = queries.split('&').find(|q| q.starts_with("cursor=")) {
                     return query.replacen("cursor=", "", 1);
                 }
             }


### PR DESCRIPTION
This addresses all but one clippy warning. The last one that it yells
about is the explicit use of a String param for a validator.
Unfortunately it needs to be a String so that we match the format of the
closure in clap.

### Is there a GIF that reflects how this work made you feel?
![america](https://user-images.githubusercontent.com/2043529/38646680-c7e67030-3d9d-11e8-8adf-ee5073567826.gif)
