### PR TITLE
Add an order trait and derive it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,8 @@ nursery: https://github.com/rust-lang-nursery/rustfmt
 Naming and conventions to improve the public interface should be followed and considered. We want
 sdk to be as easy to use as possible.
 
+### Traits
+
 When developing a trait please consider that traits are more like verbs than nouns. As such the
 convention has been to utilize words like `Clone` instead of `Cloneable` and `Write` instead of
 `Writer`. Sometimes a noun might make the right word but generally we should favor describing
@@ -106,6 +108,22 @@ what it does rather than what it is.
 
 There is an open proposal for this on the rust-lang nursery:
 https://github.com/rust-lang-nursery/api-guidelines/issues/28
+
+### Builder methods
+
+When making a builder method use a `with_` prefix instead of a setter:
+
+```rust
+
+// BAD
+fn set_value(mut self, val: Value) -> Self;
+
+// BAD
+fn value(mut self, val: Value) -> Self;
+
+// GOOD
+fn with_value(mut self, val: Value) -> Self;
+```
 
 ## Proposing changes
 

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,5 +1,5 @@
 use clap::ArgMatches;
-use stellar_client::{sync, endpoint::{account, Limit}, error::Result, sync::Client};
+use stellar_client::{sync, endpoint::{account, Limit, Order}, error::Result, sync::Client};
 use super::{cursor, ordering, pager::Pager};
 
 pub fn details(client: &Client, matches: &ArgMatches) -> Result<()> {
@@ -19,7 +19,7 @@ pub fn transactions(client: &Client, matches: &ArgMatches) -> Result<()> {
     let id = matches.value_of("ID").expect("ID is required");
     let endpoint = {
         let endpoint = account::Transactions::new(id)
-            .order(ordering::from_arg(matches))
+            .with_order(ordering::from_arg(matches))
             .with_limit(pager.horizon_page_limit() as u32);
         cursor::assign_from_arg(matches, endpoint)
     };

--- a/cli/src/assets.rs
+++ b/cli/src/assets.rs
@@ -1,4 +1,4 @@
-use stellar_client::{endpoint::{asset, Limit}, error::Result, sync::{self, Client}};
+use stellar_client::{endpoint::{asset, Limit, Order}, error::Result, sync::{self, Client}};
 use clap::ArgMatches;
 use super::{cursor, ordering, pager::Pager};
 
@@ -9,14 +9,14 @@ pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
 
     let endpoint = {
         let mut endpoint = asset::All::default()
-            .order(ordering::from_arg(matches))
+            .with_order(ordering::from_arg(matches))
             .with_limit(pager.horizon_page_limit() as u32);
 
         if let Some(code) = matches.value_of("code") {
-            endpoint = endpoint.asset_code(code);
+            endpoint = endpoint.with_asset_code(code);
         }
         if let Some(issuer) = matches.value_of("issuer") {
-            endpoint = endpoint.asset_issuer(issuer);
+            endpoint = endpoint.with_asset_issuer(issuer);
         }
         cursor::assign_from_arg(matches, endpoint)
     };

--- a/cli/src/ordering.rs
+++ b/cli/src/ordering.rs
@@ -1,5 +1,5 @@
 use clap::{App, Arg, ArgMatches};
-use stellar_client::endpoint::{Order, Order::Asc, Order::Desc};
+use stellar_client::endpoint::{Direction, Direction::Asc, Direction::Desc};
 
 static ARG_NAME: &'static str = "order";
 static ASC: &'static str = "asc";
@@ -19,7 +19,7 @@ pub fn add<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 /// Parses the argument matches and returns the order to use.
-pub fn from_arg(arg: &ArgMatches) -> Order {
+pub fn from_arg(arg: &ArgMatches) -> Direction {
     match arg.value_of(ARG_NAME) {
         Some(s) if s == ASC => Asc,
         Some(s) if s == DESC => Desc,

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -1,4 +1,4 @@
-use stellar_client::{endpoint::{transaction, Limit}, error::Result, sync::{self, Client}};
+use stellar_client::{endpoint::{transaction, Limit, Order}, error::Result, sync::{self, Client}};
 use clap::ArgMatches;
 use super::{cursor, ordering, pager::Pager};
 
@@ -6,7 +6,7 @@ pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
     let endpoint = {
         let endpoint = transaction::All::default()
-            .order(ordering::from_arg(matches))
+            .with_order(ordering::from_arg(matches))
             .with_limit(pager.horizon_page_limit() as u32);
         cursor::assign_from_arg(matches, endpoint)
     };

--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::{Account, Datum, Effect, Operation, Transaction};
-use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
+use super::{Body, Cursor, Direction, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the account details on the stellar horizon server.
@@ -155,11 +155,11 @@ mod details_tests {
 ///
 /// assert!(acct_txns.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Transactions {
     id: String,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -179,21 +179,6 @@ impl Transactions {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{account, Order};
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = account::Transactions::new("abc123").order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -256,7 +241,7 @@ mod transactions_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Transactions::new("abc123")
             .with_cursor("CURSOR")
-            .order(Order::Desc)
+            .with_order(Direction::Desc)
             .with_limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/accounts/abc123/transactions");
@@ -291,11 +276,11 @@ mod transactions_tests {
 ///
 /// assert!(effects.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Effects {
     id: String,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -315,21 +300,6 @@ impl Effects {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{account, Order};
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = account::Effects::new("abc123").order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -392,7 +362,7 @@ mod effects_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Effects::new("abc123")
             .with_cursor("CURSOR")
-            .order(Order::Asc)
+            .with_order(Direction::Asc)
             .with_limit(123);
         let req = ep.into_request("https://horizon-testnet.stellar.org")
             .unwrap();
@@ -427,11 +397,11 @@ mod effects_tests {
 ///
 /// assert!(account_operations.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Operations {
     account_id: String,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -450,22 +420,6 @@ impl Operations {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{account, Order};
-    ///
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = account::Operations::new("abc123").order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -518,7 +472,7 @@ mod ledger_operations_tests {
         let ep = Operations::new("abc123")
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/accounts/abc123/operations");
         assert_eq!(
@@ -561,11 +515,11 @@ mod ledger_operations_tests {
 /// assert!(acct_payments.records().len() > 0);
 /// # }
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Payments {
     id: String,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -585,21 +539,6 @@ impl Payments {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{account, Order};
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = account::Payments::new("abc123").order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -653,7 +592,7 @@ mod payments_tests {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Payments::new("abc123")
             .with_cursor("CURSOR")
-            .order(Order::Desc)
+            .with_order(Direction::Desc)
             .with_limit(123);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/accounts/abc123/payments");

--- a/client/src/endpoint/asset.rs
+++ b/client/src/endpoint/asset.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Asset;
-use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
+use super::{Body, Cursor, Direction, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all assets end point for the stellar horizon server. The endpoint
@@ -22,12 +22,12 @@ use http::{Request, Uri};
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Clone, Cursor, Limit)]
+#[derive(Debug, Default, Clone, Cursor, Limit, Order)]
 pub struct All {
     code: Option<String>,
     issuer: Option<String>,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -41,13 +41,13 @@ impl All {
     /// use stellar_client::endpoint::asset;
     ///
     /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = asset::All::default().asset_code("USD");
+    /// let endpoint    = asset::All::default().with_asset_code("USD");
     /// let records     = client.request(endpoint).unwrap();
     /// #
     /// # assert!(records.records().len() > 0);
     /// # assert_eq!(records.records()[0].code(), "USD");
     /// ```
-    pub fn asset_code(mut self, code: &str) -> Self {
+    pub fn with_asset_code(mut self, code: &str) -> Self {
         self.code = Some(code.to_string());
         self
     }
@@ -61,36 +61,17 @@ impl All {
     /// use stellar_client::endpoint::asset;
     ///
     /// let client = Client::horizon_test().unwrap();
-    /// # let endpoint = asset::All::default().asset_code("USD");
+    /// # let endpoint = asset::All::default().with_asset_code("USD");
     /// # let records = client.request(endpoint).unwrap();
     /// # let issuer = records.records()[0].issuer();
-    /// let endpoint = asset::All::default().asset_issuer(issuer);
+    /// let endpoint = asset::All::default().with_asset_issuer(issuer);
     /// let records = client.request(endpoint).unwrap();
     /// #
     /// # assert!(records.records().len() > 0);
     /// # assert_eq!(records.records()[0].issuer(), issuer);
     /// ```
-    pub fn asset_issuer(mut self, issuer: &str) -> Self {
+    pub fn with_asset_issuer(mut self, issuer: &str) -> Self {
         self.issuer = Some(issuer.to_string());
-        self
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::sync::Client;
-    /// use stellar_client::endpoint::{asset, Order};
-    ///
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = asset::All::default().order(Order::Asc);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert!(records.records().len() > 0);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
         self
     }
 
@@ -150,11 +131,11 @@ mod all_assets_tests {
     #[test]
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
-            .asset_code("CODE")
-            .asset_issuer("ISSUER")
+            .with_asset_code("CODE")
+            .with_asset_issuer("ISSUER")
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/assets");
         assert_eq!(

--- a/client/src/endpoint/effect.rs
+++ b/client/src/endpoint/effect.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Effect;
-use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
+use super::{Body, Cursor, Direction, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 pub use super::account::Effects as ForAccount;
 pub use super::ledger::Effects as ForLedger;
@@ -23,33 +23,14 @@ pub use super::ledger::Effects as ForLedger;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Cursor, Limit)]
+#[derive(Debug, Default, Cursor, Limit, Order)]
 pub struct All {
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
 impl All {
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use stellar_client::sync::Client;
-    /// # use stellar_client::endpoint::{effect, Order};
-    /// #
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = effect::All::default().order(Order::Asc);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert!(records.records().len() > 0);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
-    }
-
     fn has_query(&self) -> bool {
         self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
     }
@@ -100,7 +81,7 @@ mod all_effects_tests {
         let ep = All::default()
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/effects");
         assert_eq!(

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::{Effect, Ledger, Operation, Transaction};
-use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
+use super::{Body, Cursor, Direction, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 /// Represents the all ledgers end point for the stellar horizon server. The endpoint
@@ -21,33 +21,14 @@ use http::{Request, Uri};
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Clone, Cursor, Limit)]
+#[derive(Debug, Default, Clone, Cursor, Limit, Order)]
 pub struct All {
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
 impl All {
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use stellar_client::sync::Client;
-    /// # use stellar_client::endpoint::{ledger, Order};
-    /// #
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = ledger::All::default().order(Order::Asc);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert!(records.records().len() > 0);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
-    }
-
     fn has_query(&self) -> bool {
         self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
     }
@@ -98,7 +79,7 @@ mod all_ledgers_tests {
         let ep = All::default()
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers");
         assert_eq!(
@@ -196,11 +177,11 @@ mod ledger_details_tests {
 ///
 /// assert!(payments.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Payments {
     sequence: u32,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -219,22 +200,6 @@ impl Payments {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{ledger, Order};
-    ///
-    /// # // Not making requests seeing as the main documentation has it.
-    /// # // This is just to document the usage and conserve hits to horizon.
-    /// let endpoint = ledger::Payments::new(123).order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -287,7 +252,7 @@ mod ledger_payments_tests {
         let ep = Payments::new(123)
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers/123/payments");
         assert_eq!(
@@ -320,11 +285,11 @@ mod ledger_payments_tests {
 ///
 /// assert!(ledger_txns.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Transactions {
     sequence: u32,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -343,22 +308,6 @@ impl Transactions {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{ledger, Order};
-    ///
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = ledger::Transactions::new(123).order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -411,7 +360,7 @@ mod ledger_transactions_tests {
         let ep = Transactions::new(123)
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers/123/transactions");
         assert_eq!(
@@ -446,11 +395,11 @@ mod ledger_transactions_tests {
 ///
 /// assert!(ledger_effects.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Effects {
     sequence: u32,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -469,22 +418,6 @@ impl Effects {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{ledger, Order};
-    ///
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = ledger::Effects::new(123).order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -537,7 +470,7 @@ mod ledger_effects_tests {
         let ep = Effects::new(123)
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers/123/effects");
         assert_eq!(
@@ -572,11 +505,11 @@ mod ledger_effects_tests {
 ///
 /// assert!(ledger_operations.records().len() > 0);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Operations {
     sequence: u32,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -595,22 +528,6 @@ impl Operations {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{ledger, Order};
-    ///
-    /// # // Not making requests seeing as the main documentation already does this.
-    /// # // This serves to document the usage while conserving hits to horizon.
-    /// let endpoint = ledger::Operations::new(123).order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -663,7 +580,7 @@ mod ledger_operations_tests {
         let ep = Operations::new(123)
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/ledgers/123/operations");
         assert_eq!(

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -28,13 +28,16 @@ pub mod ledger;
 pub mod operation;
 pub mod payment;
 pub mod transaction;
+
 mod cursor;
 mod limit;
 mod records;
+mod order;
 
 pub use self::cursor::Cursor;
 pub use self::limit::Limit;
 pub use self::records::Records;
+pub use self::order::{Direction, Order};
 
 /// Represents the body of a request to an IntoRequest.
 #[derive(Debug)]
@@ -51,35 +54,4 @@ pub trait IntoRequest {
 
     /// Converts the implementing struct into an http request.
     fn into_request(self, host: &str) -> Result<http::Request<Body>>;
-}
-
-/// The order to return results in.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Order {
-    /// Order the results ascending
-    Asc,
-    /// Order the results descending
-    Desc,
-}
-
-use std::string::ToString;
-
-impl ToString for Order {
-    fn to_string(&self) -> String {
-        match *self {
-            Order::Asc => "asc".to_string(),
-            Order::Desc => "desc".to_string(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod order_tests {
-    use super::*;
-
-    #[test]
-    fn it_can_become_a_string() {
-        assert_eq!(Order::Asc.to_string(), "asc");
-        assert_eq!(Order::Desc.to_string(), "desc");
-    }
 }

--- a/client/src/endpoint/operation.rs
+++ b/client/src/endpoint/operation.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Operation;
-use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
+use super::{Body, Cursor, Direction, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 pub use super::account::Operations as ForAccount;
@@ -25,28 +25,14 @@ pub use super::transaction::Operations as ForTransaction;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Clone, Cursor, Limit)]
+#[derive(Debug, Default, Clone, Cursor, Limit, Order)]
 pub struct All {
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
 impl All {
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{operation, Order};
-    ///
-    /// let endpoint = operation::All::default().order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
-    }
-
     fn has_query(&self) -> bool {
         self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
     }
@@ -97,7 +83,7 @@ mod all_operationss_tests {
         let ep = All::default()
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/operations");
         assert_eq!(

--- a/client/src/endpoint/order.rs
+++ b/client/src/endpoint/order.rs
@@ -1,0 +1,63 @@
+/// Declares that this endpoint has an order field and can have it set.
+///
+/// ## Example
+///
+/// ```
+/// use stellar_client::endpoint::{Direction, Order, transaction};
+///
+/// let txns = transaction::All::default();
+/// assert_eq!(txns.order(), None);
+///
+/// let txns = txns.with_order(Direction::Asc);
+/// assert_eq!(txns.order(), Some(Direction::Asc));
+///
+/// ```
+pub trait Order {
+    /// Sets the order on the struct and returns an owned version.
+    fn with_order(self, order: Direction) -> Self;
+
+    /// Returns the order that has been set, if it has been set.
+    fn order(&self) -> Option<Direction>;
+}
+
+/// The order to return results in.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Direction {
+    /// Order the results ascending
+    Asc,
+    /// Order the results descending
+    Desc,
+}
+
+use std::string::ToString;
+
+impl ToString for Direction {
+    fn to_string(&self) -> String {
+        match *self {
+            Direction::Asc => "asc".to_string(),
+            Direction::Desc => "desc".to_string(),
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_become_a_string() {
+        assert_eq!(Direction::Asc.to_string(), "asc");
+        assert_eq!(Direction::Desc.to_string(), "desc");
+    }
+
+    #[test]
+    fn it_can_be_derived() {
+        #[derive(Order)]
+        struct Foo {
+            order: Option<Direction>,
+        }
+
+        let foo = Foo { order: None }.with_order(Direction::Asc);
+        assert_eq!(foo.order, Some(Direction::Asc));
+        assert_eq!(foo.order(), Some(Direction::Asc));
+    }
+}

--- a/client/src/endpoint/payment.rs
+++ b/client/src/endpoint/payment.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::Operation;
-use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
+use super::{Body, Cursor, Direction, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 pub use super::transaction::Payments as ForTransaction;
@@ -25,33 +25,14 @@ pub use super::account::Payments as ForAccount;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Cursor, Limit)]
+#[derive(Debug, Default, Cursor, Limit, Order)]
 pub struct All {
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
 impl All {
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use stellar_client::sync::Client;
-    /// # use stellar_client::endpoint::{payment, Order};
-    /// #
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = payment::All::default().order(Order::Asc);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert!(records.records().len() > 0);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
-    }
-
     fn has_query(&self) -> bool {
         self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
     }
@@ -102,7 +83,7 @@ mod all_payments_tests {
         let ep = All::default()
             .with_cursor("CURSOR")
             .with_limit(123)
-            .order(Order::Desc);
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/payments");
         assert_eq!(

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -2,7 +2,7 @@
 use error::Result;
 use std::str::FromStr;
 use stellar_resources::{Operation, Transaction};
-use super::{Body, Cursor, IntoRequest, Limit, Order, Records};
+use super::{Body, Cursor, Direction, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 pub use super::account::Transactions as ForAccount;
 pub use super::ledger::Transactions as ForLedger;
@@ -24,33 +24,14 @@ pub use super::ledger::Transactions as ForLedger;
 /// #
 /// # assert!(records.records().len() > 0);
 /// ```
-#[derive(Debug, Default, Clone, Cursor, Limit)]
+#[derive(Debug, Default, Clone, Cursor, Limit, Order)]
 pub struct All {
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
 impl All {
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::sync::Client;
-    /// use stellar_client::endpoint::{transaction, Order};
-    ///
-    /// let client      = Client::horizon_test().unwrap();
-    /// let endpoint    = transaction::All::default().order(Order::Asc);
-    /// let records     = client.request(endpoint).unwrap();
-    /// #
-    /// # assert!(records.records().len() > 0);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
-    }
-
     fn has_query(&self) -> bool {
         self.order.is_some() || self.cursor.is_some() || self.limit.is_some()
     }
@@ -99,8 +80,8 @@ mod all_transactions_test {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = All::default()
             .with_cursor("CURSOR")
-            .order(Order::Desc)
-            .with_limit(123);
+            .with_limit(123)
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/transactions");
         assert_eq!(
@@ -194,11 +175,11 @@ mod transaction_details_tests {
 /// assert!(payments.records().len() > 0);
 /// assert_eq!(payments.records()[0].transaction(), hash);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Payments {
     hash: String,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -211,20 +192,6 @@ impl Payments {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{transaction, Order};
-    ///
-    /// let endpoint = transaction::Payments::new("ABC123").order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -275,8 +242,8 @@ mod transaction_payments_test {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Payments::new("HASH123")
             .with_cursor("CURSOR")
-            .order(Order::Desc)
-            .with_limit(123);
+            .with_limit(123)
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/transactions/HASH123/payments");
         assert_eq!(
@@ -310,11 +277,11 @@ mod transaction_payments_test {
 /// assert!(operations.records().len() > 0);
 /// assert_eq!(operations.records()[0].transaction(), hash);
 /// ```
-#[derive(Debug, Clone, Cursor, Limit)]
+#[derive(Debug, Clone, Cursor, Limit, Order)]
 pub struct Operations {
     hash: String,
     cursor: Option<String>,
-    order: Option<Order>,
+    order: Option<Direction>,
     limit: Option<u32>,
 }
 
@@ -327,20 +294,6 @@ impl Operations {
             order: None,
             limit: None,
         }
-    }
-
-    /// Fetches all records in a set order, either ascending or descending.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use stellar_client::endpoint::{transaction, Order};
-    ///
-    /// let endpoint = transaction::Operations::new("ABC123").order(Order::Asc);
-    /// ```
-    pub fn order(mut self, order: Order) -> Self {
-        self.order = Some(order);
-        self
     }
 
     fn has_query(&self) -> bool {
@@ -391,8 +344,8 @@ mod transaction_operations_test {
     fn it_puts_the_query_params_on_the_uri() {
         let ep = Operations::new("HASH123")
             .with_cursor("CURSOR")
-            .order(Order::Desc)
-            .with_limit(123);
+            .with_limit(123)
+            .with_order(Direction::Desc);
         let req = ep.into_request("https://www.google.com").unwrap();
         assert_eq!(req.uri().path(), "/transactions/HASH123/operations");
         assert_eq!(

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -44,7 +44,6 @@ pub fn cursor(input: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(Limit)]
 pub fn limit(input: TokenStream) -> TokenStream {
-    // Parse the string representation
     let ast: DeriveInput = syn::parse(input).unwrap();
     let name = &ast.ident;
 
@@ -71,5 +70,39 @@ pub fn limit(input: TokenStream) -> TokenStream {
         }
     } else {
         panic!("#[derive(Limit)] is only valid for structs")
+    }
+}
+
+#[proc_macro_derive(Order)]
+pub fn order(input: TokenStream) -> TokenStream {
+    // Parse the string representation
+    let ast: DeriveInput = syn::parse(input).unwrap();
+    let name = &ast.ident;
+
+    if let Data::Struct(data) = ast.data {
+        if data.fields
+            .iter()
+            .any(|f| f.ident == Some(Ident::from("order")))
+        {
+            let code = quote! {
+                impl Order for #name {
+                    fn with_order(mut self, order: Direction) -> #name {
+                        self.order = Some(order);
+                        self
+                    }
+
+                    fn order(&self) -> Option<Direction> {
+                        self.order
+                    }
+                }
+            };
+            code.into()
+        } else {
+            panic!(
+                "#[derive(Order)] is only valid for structs that define `order: Option<Direction>`"
+            )
+        }
+    } else {
+        panic!("#[derive(Order)] is only valid for structs")
     }
 }


### PR DESCRIPTION
To simplify the creation of endpoints and maintenance, this creates an
`Order` trait and renames the direction of the order to `Direction`.
This allows us to then use a procedural macro to derive the trait. Also,
it enables some additional simplifications in the cli in the future.

Also in this change is modifying asset_code and asset_issuer setters to
use the `with_` prefix.

closes #135

### Is there a GIF that reflects how this work made you feel?
