### PR TITLE
Add find path action to the payments endpoint

### DIFF
--- a/client/src/endpoint/flat_records.rs
+++ b/client/src/endpoint/flat_records.rs
@@ -1,0 +1,81 @@
+use serde::de::{Deserialize, DeserializeOwned, Deserializer};
+use std;
+
+/// A struct that represents a set of records returned from the horizon api.
+///
+/// Use this struct when querying an end point that returns an index route with
+/// embedded resources, but _no_ `_links` object with cursor(s) to paginate.
+#[derive(Debug)]
+pub struct FlatRecords<T>
+where
+    T: DeserializeOwned,
+{
+    records: Vec<T>,
+}
+
+impl<T> FlatRecords<T>
+where
+    T: DeserializeOwned,
+{
+    /// Returns a slice of the embedded records.
+    pub fn records(&self) -> &Vec<T> {
+        &self.records
+    }
+}
+
+impl<'de, T> Deserialize<'de> for FlatRecords<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D>(d: D) -> std::result::Result<FlatRecords<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let embedded: Embedded<RecordsIntermediate<T>> = Embedded::deserialize(d)?;
+        Ok(FlatRecords {
+            records: embedded.embedded.records,
+        })
+    }
+}
+
+/// The HAL response format will embed resources within it. When it does
+/// this provides a wrapper to the `_embedded` key.
+///
+/// https://www.stellar.org/developers/horizon/reference/responses.html
+#[derive(Deserialize)]
+struct Embedded<T> {
+    #[serde(rename = "_embedded")]
+    embedded: T,
+}
+
+/// If the embedded resource is a set of records, this can provide that data back in
+/// a generic way.
+#[derive(Deserialize)]
+struct RecordsIntermediate<T> {
+    records: Vec<T>,
+}
+
+#[cfg(test)]
+mod records_test {
+    use super::*;
+    use serde_json;
+
+    #[derive(Deserialize)]
+    struct Foo {
+        foo: String,
+    }
+
+    #[test]
+    fn it_parses_out_a_embedded_records_string() {
+        let json = r#"
+        {
+            "_embedded": {
+                "records": [
+                    { "foo": "bar" }
+                ]
+            }
+        }"#;
+        let records: FlatRecords<Foo> = serde_json::from_str(&json).unwrap();
+        assert_eq!(records.records().first().unwrap().foo, "bar");
+    }
+}

--- a/client/src/endpoint/mod.rs
+++ b/client/src/endpoint/mod.rs
@@ -32,11 +32,13 @@ pub mod transaction;
 mod cursor;
 mod limit;
 mod records;
+mod flat_records;
 mod order;
 
 pub use self::cursor::Cursor;
 pub use self::limit::Limit;
 pub use self::records::Records;
+pub use self::flat_records::FlatRecords;
 pub use self::order::{Direction, Order};
 
 /// Represents the body of a request to an IntoRequest.

--- a/client/src/endpoint/payment.rs
+++ b/client/src/endpoint/payment.rs
@@ -1,8 +1,8 @@
 //! Contains the endpoint for all payment operations.
 use error::Result;
 use std::str::FromStr;
-use stellar_resources::Operation;
-use super::{Body, Cursor, Direction, IntoRequest, Limit, Order, Records};
+use stellar_resources::{Amount, AssetIdentifier, Operation, PaymentPath};
+use super::{Body, Cursor, Direction, FlatRecords, IntoRequest, Limit, Order, Records};
 use http::{Request, Uri};
 
 pub use super::transaction::Payments as ForTransaction;
@@ -89,6 +89,183 @@ mod all_payments_tests {
         assert_eq!(
             req.uri().query(),
             Some("order=desc&cursor=CURSOR&limit=123")
+        );
+    }
+}
+
+/// This endpoint represents a search for a series of assets through which to route a payment,
+/// from source asset (debited from payer) to destination asset (credited to payee).
+/// The endpoint will return any payment paths using assets available to a source account to the
+/// desired destination asset.
+///
+/// <https://www.stellar.org/developers/horizon/reference/endpoints/path-finding.html>
+///
+/// ## Example
+/// ```
+/// # extern crate stellar_client;
+/// # extern crate stellar_resources;
+/// use stellar_client::sync::Client;
+/// use stellar_client::endpoint::{payment, Limit};
+/// use stellar_resources::{Amount, AssetIdentifier, OperationKind};
+///
+/// # fn main() {
+/// let client = Client::horizon_test().unwrap();
+///
+/// // Cast a wide net for `create_account` operations to ensure two valid accounts.
+/// let operations  = client.request(payment::All::default().with_limit(20)).unwrap();
+/// let account_ids = &operations
+///     .records()
+///     .iter()
+///     .filter_map(|op| {
+///         match op.kind() {
+///           &OperationKind::CreateAccount(ref acct) => Some(acct.account()),
+///           _ => None
+///         }
+///     })
+///     .take(2)
+///     .collect::<Vec<&str>>();
+/// # assert_eq!(account_ids.len(), 2);
+///
+/// let endpoint = payment::FindPath::new(
+///     &account_ids[0], // source_account
+///     &account_ids[1], // destination_account
+///     AssetIdentifier::Native,
+///     Amount::new(1)
+/// );
+///
+/// // Now we issue a request for a path to payment of 1 stroop
+/// let records = client.request(endpoint).unwrap();
+///
+/// assert!(records.records().len() > 0);
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct FindPath {
+    source_account: String,
+    destination_account: String,
+    destination_asset: AssetIdentifier,
+    destination_amount: Amount,
+}
+
+impl FindPath {
+    /// Creates a new payment::FindPath endpoint struct. Hand this to the client
+    /// in order to request series of assets through which to route a desired
+    /// payment.
+    ///
+    /// ```
+    /// # extern crate stellar_client;
+    /// # extern crate stellar_resources;
+    /// use stellar_client::endpoint::payment;
+    /// use stellar_resources::{Amount, AssetIdentifier};
+    ///
+    /// # fn main() {
+    /// let paths = payment::FindPath::new(
+    ///     "source_account",
+    ///     "destination_account",
+    ///     AssetIdentifier::new(
+    ///         "credit_alphanum4",
+    ///         Some("code".to_string()),
+    ///         Some("issuer".to_string())
+    ///     ).unwrap(),
+    ///     Amount::new(8675309)
+    /// );
+    /// # }
+    /// ```
+    pub fn new(
+        source_account: &str,
+        destination_account: &str,
+        destination_asset: AssetIdentifier,
+        destination_amount: Amount,
+    ) -> Self {
+        Self {
+            source_account: source_account.to_string(),
+            destination_account: destination_account.to_string(),
+            destination_asset,
+            destination_amount,
+        }
+    }
+}
+
+impl IntoRequest for FindPath {
+    type Response = FlatRecords<PaymentPath>;
+
+    fn into_request(self, host: &str) -> Result<Request<Body>> {
+        let mut uri = format!(
+            "{}/paths?source_account={}&destination_account={}&\
+             destination_amount={}&destination_asset_type={}",
+            host,
+            self.source_account,
+            self.destination_account,
+            self.destination_amount,
+            self.destination_asset.asset_type()
+        );
+        if !self.destination_asset.is_native() {
+            uri.push_str(&format!(
+                "&destination_asset_code={}",
+                self.destination_asset.asset_code().unwrap()
+            ));
+            uri.push_str(&format!(
+                "&destination_asset_issuer={}",
+                self.destination_asset.issuer().to_string()
+            ));
+        }
+
+        let uri = Uri::from_str(&uri)?;
+        let request = Request::get(uri).body(Body::None)?;
+        Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod find_path_tests {
+    use super::*;
+
+    #[test]
+    fn it_can_make_a_paths_uri_for_native_assets() {
+        let paths = FindPath::new(
+            "account_a",
+            "account_b",
+            AssetIdentifier::new("native", None, None).unwrap(),
+            Amount::new(1000),
+        );
+        let request = paths
+            .into_request("https://horizon-testnet.stellar.org")
+            .unwrap();
+        assert_eq!(request.uri().host().unwrap(), "horizon-testnet.stellar.org");
+        assert_eq!(request.uri().path(), "/paths");
+        assert_eq!(
+            request.uri().query(),
+            Some(
+                "source_account=account_a&destination_account=account_b&\
+                 destination_amount=0.0001000&destination_asset_type=native"
+            )
+        );
+    }
+
+    #[test]
+    fn it_can_make_a_paths_uri_for_non_native_assets() {
+        let paths = FindPath::new(
+            "account_a",
+            "account_b",
+            AssetIdentifier::new(
+                "credit_alphanum4",
+                Some("codx".to_string()),
+                Some("me".to_string()),
+            ).unwrap(),
+            Amount::new(1000),
+        );
+        let request = paths
+            .into_request("https://horizon-testnet.stellar.org")
+            .unwrap();
+        assert_eq!(request.uri().host().unwrap(), "horizon-testnet.stellar.org");
+        assert_eq!(request.uri().path(), "/paths");
+        assert_eq!(
+            request.uri().query(),
+            Some(
+                "source_account=account_a&destination_account=account_b&\
+                 destination_amount=0.0001000&destination_asset_type=credit_alphanum4&\
+                 destination_asset_code=codx&destination_asset_issuer=me"
+            )
         );
     }
 }

--- a/resources/src/amount.rs
+++ b/resources/src/amount.rs
@@ -131,7 +131,7 @@ mod serialize_amount_tests {
 
 /// The stellar ammount fields are represented as strings in the horizon api,
 /// however, they look like floats. But, in the actual ledger they are signed
-/// 64-bit integers. This function converst what we get from horizon into a
+/// 64-bit integers. This function converts what we get from horizon into a
 /// signed integer. The precision of the float is assumed to be out to 7
 /// digits (but if fewer are found it's ok).
 


### PR DESCRIPTION
This implements the find payment path operation to find possible routes to
deliver assets between accounts on the network.

It adds a new response records struct for use with endpoints that lack
pagination, such as find path.

Fixes #76

### Is there a GIF that reflects how this work made you feel?
![](https://media.giphy.com/media/d3MMEa9PT2eYAKGY/giphy.gif)