### PR TITLE
Remove Serialize from resources

### DIFF
--- a/resources/src/account.rs
+++ b/resources/src/account.rs
@@ -6,7 +6,7 @@ use base64string::Base64String;
 /// corresponding keypair that can authorize transactions.
 ///
 /// <https://www.stellar.org/developers/horizon/reference/resources/account.html>
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Account {
     id: String,
     account_id: String,

--- a/resources/src/asset.rs
+++ b/resources/src/asset.rs
@@ -255,7 +255,7 @@ mod asset_identifier_tests {
 
 /// Permissions around who can own an asset and whether or
 /// not the asset issuer can freeze the asset.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Flag {
     auth_required: bool,
     auth_revocable: bool,
@@ -283,7 +283,7 @@ pub struct Asset {
     flags: Flag,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct IntermediateAsset {
     asset_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -310,33 +310,6 @@ impl<'de> Deserialize<'de> for Asset {
             num_accounts: rep.num_accounts,
             flags: rep.flags,
         })
-    }
-}
-
-impl Serialize for Asset {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let rep: IntermediateAsset = match self.asset_type() {
-            "native" => IntermediateAsset {
-                asset_type: self.asset_type().to_owned(),
-                asset_code: None,
-                asset_issuer: None,
-                amount: self.amount,
-                num_accounts: self.num_accounts,
-                flags: self.flags,
-            },
-            _ => IntermediateAsset {
-                asset_type: self.asset_type().to_owned(),
-                asset_code: Some(self.code().to_owned()),
-                asset_issuer: Some(self.issuer().to_owned()),
-                amount: self.amount,
-                num_accounts: self.num_accounts,
-                flags: self.flags,
-            },
-        };
-        rep.serialize(s)
     }
 }
 
@@ -416,24 +389,4 @@ mod asset_tests {
         assert!(!asset.is_auth_required());
         assert!(asset.is_auth_revocable());
     }
-
-    #[test]
-    fn it_serializes_non_native_assets() {
-        let asset: Asset = serde_json::from_str(&asset_json()).unwrap();
-        assert_eq!(
-            serde_json::to_string(&asset).unwrap(),
-            "{\
-             \"asset_type\":\"credit_alphanum4\",\
-             \"asset_code\":\"USD\",\
-             \"asset_issuer\":\"GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG\",\
-             \"amount\":\"100.0000000\",\
-             \"num_accounts\":91547871,\
-             \"flags\":{\
-             \"auth_required\":false,\
-             \"auth_revocable\":true\
-             }\
-             }"
-        );
-    }
-
 }

--- a/resources/src/datum.rs
+++ b/resources/src/datum.rs
@@ -5,7 +5,7 @@ use base64string::Base64String;
 /// for various reasons. Datum represents the value of a single key/value pair.
 ///
 /// <https://www.stellar.org/developers/horizon/reference/resources/data.html>
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Datum {
     value: Base64String,
 }

--- a/resources/src/ledger.rs
+++ b/resources/src/ledger.rs
@@ -3,7 +3,7 @@ use amount::Amount;
 
 /// A ledger represents the state of the Stellar universe at a given point in time. It contains the list of all the accounts and balances, all the orders in the distributed exchange, and any other data that persists.
 /// The first ledger in the history of the network is called the genesis ledger.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 pub struct Ledger {
     id: String,
     paging_token: String,

--- a/resources/src/offer.rs
+++ b/resources/src/offer.rs
@@ -31,7 +31,7 @@ impl PriceRatio {
 }
 
 /// Summary of an offer to be shown in an orderbook
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct OfferSummary {
     amount: Amount,
     #[serde(rename = "price_r")]
@@ -75,7 +75,7 @@ mod offer_summary_tests {
 }
 
 /// An offer being made for particular assets at a particular exchange rate.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Offer {
     id: i64,
     paging_token: String,

--- a/resources/src/orderbook.rs
+++ b/resources/src/orderbook.rs
@@ -6,7 +6,7 @@ use asset::AssetIdentifier;
 /// The asset pairs are refered to as a base and counter.
 ///
 /// <https://www.stellar.org/developers/horizon/reference/resources/orderbook.html>
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Orderbook {
     bids: Vec<OfferSummary>,
     asks: Vec<OfferSummary>,

--- a/resources/src/payment_path.rs
+++ b/resources/src/payment_path.rs
@@ -1,4 +1,4 @@
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de, Deserialize, Deserializer};
 use asset::AssetIdentifier;
 use amount::Amount;
 
@@ -58,7 +58,7 @@ impl PaymentPath {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 struct IntermediatePaymentPath {
     path: Vec<AssetIdentifier>,
     destination_amount: Amount,
@@ -97,26 +97,6 @@ impl<'de> Deserialize<'de> for PaymentPath {
     }
 }
 
-impl Serialize for PaymentPath {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let rep = IntermediatePaymentPath {
-            path: self.path.clone(),
-            source_amount: self.source_amount().to_owned(),
-            destination_amount: self.destination_amount().to_owned(),
-            destination_asset_type: self.destination_asset().asset_type().to_string(),
-            destination_asset_code: self.destination_asset().asset_code(),
-            destination_asset_issuer: self.destination_asset().asset_issuer(),
-            source_asset_type: self.source_asset().asset_type().to_string(),
-            source_asset_code: self.source_asset().asset_code(),
-            source_asset_issuer: self.source_asset().asset_issuer(),
-        };
-        rep.serialize(s)
-    }
-}
-
 #[cfg(test)]
 mod payment_path_tests {
     use super::*;
@@ -134,31 +114,5 @@ mod payment_path_tests {
         assert_eq!(payment_path.destination_amount(), &Amount::new(200_000_000));
         assert_eq!(payment_path.destination_asset().code(), "EUR");
         assert_eq!(payment_path.source_asset().code(), "USD");
-    }
-
-    #[test]
-    fn it_serializes_payment_paths_from_json() {
-        let payment_path: PaymentPath = serde_json::from_str(&payment_path_json()).unwrap();
-        assert_eq!(
-            serde_json::to_string(&payment_path).unwrap(),
-            "{\
-             \"path\":[\
-             {\
-             \"asset_type\":\"credit_alphanum4\",\
-             \"asset_code\":\"1\",\
-             \"asset_issuer\":\"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN\"\
-             }\
-             ],\
-             \"destination_amount\":\"20.0000000\",\
-             \"destination_asset_type\":\"credit_alphanum4\",\
-             \"destination_asset_code\":\"EUR\",\
-             \"destination_asset_issuer\":\"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46U\
-             IGTHVWGWJGQKH3AFNHXHXN\",\
-             \"source_amount\":\"20.0000000\",\
-             \"source_asset_type\":\"credit_alphanum4\",\
-             \"source_asset_code\":\"USD\",\
-             \"source_asset_issuer\":\"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN\"\
-             }"
-        );
     }
 }

--- a/resources/src/transaction.rs
+++ b/resources/src/transaction.rs
@@ -6,7 +6,7 @@ use deserialize;
 /// A transaction is a grouping of operations.
 ///
 /// To learn more about the concept of transactions in the Stellar network, take a look at the Stellar transactions concept guide.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Transaction {
     id: String,
     paging_token: String,


### PR DESCRIPTION
From all of the top level resources, the serialize implementation has
been removed. This will force users to implement their own
serializations and not be dependent on mimicing the same schema as the
horizon API. It does leave the serialize trait on some types that are
basal. These are `AssetIdentifier`, `Amount`, `PriceRatio`, and
`Base64String`. I felt that these would likely be reused in other types
and thus are useful to have serialize on.

closes #128

### Is there a GIF that reflects how this work made you feel?
![bump](https://user-images.githubusercontent.com/2043529/38744131-d527572e-3ef5-11e8-8a2b-8d567f9b522d.gif)
