### PR TITLE
Add operations for transaction to CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,6 +103,17 @@ fn build_app<'a, 'b>() -> App<'a, 'b> {
                                 .help("The identifier of the transaction to look up"),
                         ),
                 )
+                .subcommand(
+                    listable!(
+                        SubCommand::with_name("operations")
+                            .about("Fetch all operations part of a given transaction")
+                            .arg(
+                                Arg::with_name("Hash")
+                                    .required(true)
+                                    .help("The transaction hash for which to fetch operations")
+                            )
+                    )
+                ),
         )
         .subcommand(
             SubCommand::with_name("assets")
@@ -152,6 +163,7 @@ fn main() {
         ("transactions", Some(sub_m)) => match sub_m.subcommand() {
             ("all", Some(sub_m)) => transactions::all(&client, sub_m),
             ("details", Some(sub_m)) => transactions::details(&client, sub_m),
+            ("operations", Some(sub_m)) => transactions::operations(&client, sub_m),
             ("payments", Some(sub_m)) => transactions::payments(&client, sub_m),
             _ => return print_help_and_exit(),
         },

--- a/resources/src/operation/mod.rs
+++ b/resources/src/operation/mod.rs
@@ -97,7 +97,7 @@ impl Operation {
         &self.paging_token
     }
 
-    /// The has for the transaction that the operation was part of
+    /// The hash for the transaction that the operation was part of
     pub fn transaction(&self) -> &str {
         &self.transaction_hash
     }
@@ -122,6 +122,23 @@ impl Operation {
     /// Returns the kind of the operation
     pub fn kind(&self) -> &Kind {
         &self.kind
+    }
+
+    /// Returns the name of the operation kind
+    pub fn kind_name(&self) -> &str {
+        match self.kind {
+            Kind::CreateAccount(_) => "Create Account",
+            Kind::Payment(_) => "Payment",
+            Kind::PathPayment(_) => "Path Payment",
+            Kind::ManageOffer(_) => "Manage Offer",
+            Kind::CreatePassiveOffer(_) => "Create Passive Offer",
+            Kind::SetOptions(_) => "Set Options",
+            Kind::ChangeTrust(_) => "Change Trust",
+            Kind::AllowTrust(_) => "Allow Trust",
+            Kind::AccountMerge(_) => "Account Merge",
+            Kind::Inflation => "Inflation",
+            Kind::ManageData(_) => "Manage Data",
+        }
     }
 
     /// Returns true if the operation is a create_account operation


### PR DESCRIPTION
Adds a command to request all operation kinds made as part of a given
transaction to the CLI application.

Fixes #148

### Is there a GIF that reflects how this work made you feel?
![](https://media.giphy.com/media/l0HlNiYlACEJPsoF2/giphy.gif)