### PR TITLE
Add effects for transaction to CLI

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,3 +12,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Transaction payments can be seen
 - Transaction details can be seen
 - All ledgers can be seen
+- Transaction operations can be seen
+- Transaction effects can be seen

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -113,6 +113,17 @@ fn build_app<'a, 'b>() -> App<'a, 'b> {
                                     .help("The transaction hash for which to fetch operations")
                             )
                     )
+                )
+                .subcommand(
+                    listable!(
+                        SubCommand::with_name("effects")
+                            .about("Fetch effects that resulted from a given transaction")
+                            .arg(
+                                Arg::with_name("Hash")
+                                    .required(true)
+                                    .help("The transaction hash for which to fetch effects")
+                            )
+                    )
                 ),
         )
         .subcommand(
@@ -176,6 +187,7 @@ fn main() {
             ("details", Some(sub_m)) => transactions::details(&client, sub_m),
             ("operations", Some(sub_m)) => transactions::operations(&client, sub_m),
             ("payments", Some(sub_m)) => transactions::payments(&client, sub_m),
+            ("effects", Some(sub_m)) => transactions::effects(&client, sub_m),
             _ => return print_help_and_exit(),
         },
         ("assets", Some(sub_m)) => match sub_m.subcommand() {

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -86,7 +86,7 @@ pub fn operations(client: &Client, matches: &ArgMatches) -> Result<()> {
         .value_of("Hash")
         .expect("Transaction identifier hash is required");
 
-    let endpoint = transaction::Payments::new(hash);
+    let endpoint = transaction::Operations::new(hash);
     let endpoint = pager.assign(endpoint);
     let endpoint = cursor::assign_from_arg(matches, endpoint);
     let endpoint = ordering::assign_from_arg(matches, endpoint);
@@ -98,6 +98,31 @@ pub fn operations(client: &Client, matches: &ArgMatches) -> Result<()> {
         Ok(op) => {
             println!("ID:   {}", op.id());
             println!("Type: {}", op.kind_name());
+            println!();
+        }
+        Err(err) => res = Err(err),
+    });
+    res
+}
+
+pub fn effects(client: &Client, matches: &ArgMatches) -> Result<()> {
+    let pager = Pager::from_arg(&matches);
+    let hash = matches
+        .value_of("Hash")
+        .expect("Transaction identifier hash is required");
+
+    let endpoint = transaction::Effects::new(hash);
+    let endpoint = pager.assign(endpoint);
+    let endpoint = cursor::assign_from_arg(matches, endpoint);
+    let endpoint = ordering::assign_from_arg(matches, endpoint);
+
+    let iter = sync::Iter::new(&client, endpoint);
+
+    let mut res = Ok(());
+    pager.paginate(iter, |result| match result {
+        Ok(effect) => {
+            println!("ID:   {}", effect.id());
+            println!("Type: {}", effect.kind_name());
             println!();
         }
         Err(err) => res = Err(err),

--- a/resources/src/effect/account/created.rs
+++ b/resources/src/effect/account/created.rs
@@ -1,7 +1,7 @@
 use amount::Amount;
 /// This effect is the result of a create account operation and represents
 /// the fact that an account was created
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Created {
     account: String,
     starting_balance: Amount,

--- a/resources/src/effect/account/credited.rs
+++ b/resources/src/effect/account/credited.rs
@@ -3,7 +3,7 @@ use asset::AssetIdentifier;
 /// This effect can be the result of a create_account, payment, path_payment
 /// or merge_account operation.  It represents the fact that assets were
 /// added to an account
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Credited {
     account: String,
     amount: Amount,

--- a/resources/src/effect/account/debited.rs
+++ b/resources/src/effect/account/debited.rs
@@ -3,7 +3,7 @@ use asset::AssetIdentifier;
 /// This effect can be the result of a create_account, payment, path_payment
 /// or merge_account operation.  It represents the fact that assets were
 /// removed to an account
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Debited {
     account: String,
     amount: Amount,

--- a/resources/src/effect/account/flags_updated.rs
+++ b/resources/src/effect/account/flags_updated.rs
@@ -1,7 +1,7 @@
 use asset::Flag;
 /// This effect can be the result of a set options operation and represents
 /// the fact that an account's flags have been updated
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct FlagsUpdated {
     account: String,
     flags: Flag,

--- a/resources/src/effect/account/home_domain_updated.rs
+++ b/resources/src/effect/account/home_domain_updated.rs
@@ -1,6 +1,6 @@
 /// This effect can be the result of a set options operation and represents
 /// the fact that an account's home domain has changed
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct HomeDomainUpdated {
     account: String,
     home_domain: String,

--- a/resources/src/effect/account/mod.rs
+++ b/resources/src/effect/account/mod.rs
@@ -18,7 +18,7 @@ pub use self::thresholds_updated::ThresholdsUpdated;
 
 /// Enum representing all the different kinds of effects that represent
 /// changes made to an account.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub enum Kind {
     /// An effect representing the fact that an account was created
     Created(Created),

--- a/resources/src/effect/account/removed.rs
+++ b/resources/src/effect/account/removed.rs
@@ -1,6 +1,6 @@
 /// This effect is the result of a create merge operation and represents
 /// the fact that an account was removed in the merge
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Removed {
     account: String,
 }

--- a/resources/src/effect/account/thresholds_updated.rs
+++ b/resources/src/effect/account/thresholds_updated.rs
@@ -1,6 +1,6 @@
 /// This effect can be the result of a set options operation and represents
 /// the fact that an account's weight thresholds have changed.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ThresholdsUpdated {
     account: String,
     low: u32,

--- a/resources/src/effect/mod.rs
+++ b/resources/src/effect/mod.rs
@@ -13,7 +13,7 @@ mod test;
 /// A successful operation will yield zero or more effects. These effects represent specific
 /// changes that occur in the ledger, but are not necessarily directly reflected in the ledger or
 /// history, as transactions and operations are.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Effect {
     id: String,
     paging_token: String,
@@ -22,7 +22,7 @@ pub struct Effect {
 
 /// Each effect type is representing by a kind and captures data specific to that
 /// type within it's newtype.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub enum EffectKind {
     /// A collection of effects that represent updates to an account
     Account(account::Kind),
@@ -80,6 +80,34 @@ impl Effect {
     /// Returns the kind of the effect
     pub fn kind(&self) -> &Kind {
         &self.kind
+    }
+
+    /// Returns the name of the effect kind
+    pub fn kind_name(&self) -> &str {
+        match self.kind {
+            Kind::Account(ref account_kind) => match *account_kind {
+                account::Kind::Created(_) => "Account created",
+                account::Kind::Removed(_) => "Account removed",
+                account::Kind::Credited(_) => "Account credited",
+                account::Kind::Debited(_) => "Account debited",
+                account::Kind::ThresholdsUpdated(_) => "Account tresholds updated",
+                account::Kind::HomeDomainUpdated(_) => "Account home domain updated",
+                account::Kind::FlagsUpdated(_) => "Flags updated",
+            },
+            Kind::Signer(ref signer_kind) => match *signer_kind {
+                signer::Kind::Created(_) => "Signer created",
+                signer::Kind::Removed(_) => "Signer removed",
+                signer::Kind::Updated(_) => "Signed updated",
+            },
+            Kind::Trustline(ref trustline_kind) => match *trustline_kind {
+                trustline::Kind::Created(_) => "Trustline created",
+                trustline::Kind::Removed(_) => "Trustline removed",
+                trustline::Kind::Updated(_) => "Trustline updated",
+                trustline::Kind::Authorized(_) => "Trustline authorized",
+                trustline::Kind::Deauthorized(_) => "Trustline deauthorized",
+            },
+            Kind::Trade(_) => "Trade",
+        }
     }
 
     /// Returns true if the effect is an account_created effect

--- a/resources/src/effect/signer/created.rs
+++ b/resources/src/effect/signer/created.rs
@@ -1,6 +1,6 @@
 /// This effect can be the result of a set options operation and represents
 /// the fact that a new signer has been created for an account.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Created {
     account: String,
     public_key: String,

--- a/resources/src/effect/signer/mod.rs
+++ b/resources/src/effect/signer/mod.rs
@@ -10,7 +10,7 @@ pub use self::updated::Updated;
 
 /// Enum representing all the different kinds of effects that represent
 /// changes made to an account signer.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub enum Kind {
     /// An effect representing the creation of a new account signer as a result of an operation
     Created(Created),

--- a/resources/src/effect/signer/removed.rs
+++ b/resources/src/effect/signer/removed.rs
@@ -1,6 +1,6 @@
 /// This effect can be the result of a set options operation and represents
 /// the fact that a new signer has been removed from an account.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Removed {
     account: String,
     public_key: String,

--- a/resources/src/effect/signer/updated.rs
+++ b/resources/src/effect/signer/updated.rs
@@ -1,6 +1,6 @@
 /// This effect can be the result of a set options operation and represents
 /// the fact that a signer has been updated for an account.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Updated {
     account: String,
     public_key: String,

--- a/resources/src/effect/trade.rs
+++ b/resources/src/effect/trade.rs
@@ -4,7 +4,7 @@ use asset::AssetIdentifier;
 
 /// Enum representing all the different kinds of effects that represent
 /// changes made to an account.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub enum Kind {
     /// An effect representing the fact that an trade occured
     Trade(Trade),
@@ -12,7 +12,7 @@ pub enum Kind {
 
 /// People on the Stellar network can make offers to buy or sell assets. When an offer is fully or
 /// partially fulfilled, a trade happens.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Trade {
     account: String,
     offer_id: i64,

--- a/resources/src/effect/trustline/authorized.rs
+++ b/resources/src/effect/trustline/authorized.rs
@@ -1,7 +1,7 @@
 use asset::AssetIdentifier;
 /// This effect can be the result of a allow trust operation and represents
 /// the fact that an asset issuer will allow an account to hold its assets.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Authorized {
     account: String,
     asset: AssetIdentifier,

--- a/resources/src/effect/trustline/created.rs
+++ b/resources/src/effect/trustline/created.rs
@@ -2,7 +2,7 @@ use amount::Amount;
 use asset::AssetIdentifier;
 /// This effect can be the result of a change trust operation and represents
 /// the fact that a new trustline has been created between an asset and account
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Created {
     account: String,
     limit: Amount,

--- a/resources/src/effect/trustline/deauthorized.rs
+++ b/resources/src/effect/trustline/deauthorized.rs
@@ -1,7 +1,7 @@
 use asset::AssetIdentifier;
 /// This effect can be the result of a allow trust operation and represents
 /// the fact that an asset issuer will no longer allow an account to hold its assets.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Deauthorized {
     account: String,
     asset: AssetIdentifier,

--- a/resources/src/effect/trustline/mod.rs
+++ b/resources/src/effect/trustline/mod.rs
@@ -14,7 +14,7 @@ pub use self::updated::Updated;
 
 /// Enum representing all the different kinds of effects that represent
 /// changes made to an account.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub enum Kind {
     /// An effect representing the creation of a trustline as a result of an operation
     Created(Created),

--- a/resources/src/effect/trustline/removed.rs
+++ b/resources/src/effect/trustline/removed.rs
@@ -2,7 +2,7 @@ use amount::Amount;
 use asset::AssetIdentifier;
 /// This effect can be the result of a change trust operation and represents
 /// the fact that a trustline has been removed between an asset and account
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Removed {
     account: String,
     limit: Amount,

--- a/resources/src/effect/trustline/updated.rs
+++ b/resources/src/effect/trustline/updated.rs
@@ -2,7 +2,7 @@ use amount::Amount;
 use asset::AssetIdentifier;
 /// This effect can be the result of a change trust operation and represents
 /// the fact that a trustline has been updated between an asset and account
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Updated {
     account: String,
     limit: Amount,


### PR DESCRIPTION
Adds a command to request all effects resulting from a given transaction
to the CLI application.

All Effects resources are modified to be Clone types.

This also fixes a copy-paste error in 68265ca

Fixes #158

### Is there a GIF that reflects how this work made you feel?
![](https://media.giphy.com/media/xUA7bbo8QK36rb4R44/giphy.gif)