### PR TITLE
Abstraction for rendering

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,6 +1,7 @@
 use clap::ArgMatches;
 use stellar_client::{sync, endpoint::account, sync::Client};
 use super::{cursor, ordering, pager::Pager};
+use fmt::{Formatter, Simple};
 use error::Result;
 
 pub fn details(client: &Client, matches: &ArgMatches) -> Result<()> {
@@ -8,8 +9,7 @@ pub fn details(client: &Client, matches: &ArgMatches) -> Result<()> {
     let endpoint = account::Details::new(id);
     let account = client.request(endpoint)?;
 
-    println!("ID:       {}", account.id());
-    println!("Sequence: {}", account.sequence());
+    Formatter::start_stdout(Simple).render(&account);
 
     Ok(())
 }

--- a/cli/src/assets.rs
+++ b/cli/src/assets.rs
@@ -2,6 +2,7 @@ use stellar_client::{endpoint::asset, sync::{self, Client}};
 use clap::ArgMatches;
 use super::{cursor, ordering, pager::Pager};
 use error::Result;
+use fmt::{Formatter, Simple};
 
 /// Using a client and the arguments from the command line, iterates over the results
 /// and displays them to the end user.
@@ -25,23 +26,11 @@ pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let iter = sync::Iter::new(&client, endpoint);
 
     let mut res = Ok(());
+    let mut fmt = Formatter::start_stdout(Simple);
     pager.paginate(iter, |result| match result {
-        Ok(asset) => {
-            println!("Code:           {}", asset.code());
-            println!("Type:           {}", asset.asset_type());
-            println!("Issuer:         {}", asset.issuer());
-            println!("Amount:         {}", asset.amount());
-            println!("Num accounts:   {}", asset.num_accounts());
-            println!("Flags:");
-            if asset.is_auth_required() {
-                println!("  auth is required");
-            }
-            if asset.is_auth_revocable() {
-                println!("  auth is revocable");
-            }
-            println!();
-        }
+        Ok(asset) => fmt.render(&asset),
         Err(err) => res = Err(err.into()),
     });
+    let _ = fmt.stop();
     res
 }

--- a/cli/src/fmt/mod.rs
+++ b/cli/src/fmt/mod.rs
@@ -1,0 +1,142 @@
+use std::io::{stdout, Stdout, Write};
+use std::marker;
+
+mod simple;
+pub use self::simple::Simple;
+
+/// The render trait can be used by the formatter to handle the calls to form
+/// output strings. The formatter will call the preamble first when it's created,
+/// then it will call the render when it's rendered, finally, when it's ended, it will
+/// call the postamble.
+pub trait Render<T> {
+    fn preamble(&self) -> Option<String> {
+        None
+    }
+
+    fn render(&self, _item: &T) -> Option<String> {
+        None
+    }
+
+    fn postamble(&self) -> Option<String> {
+        None
+    }
+}
+
+/// A formatter that takes a write and a render and will output
+/// lines of text based on what the render does.
+pub struct Formatter<T, W, R>
+where
+    W: Write,
+    R: Render<T>,
+{
+    writer: W,
+    render: R,
+    _marker: marker::PhantomData<T>,
+}
+
+impl<T, R> Formatter<T, Stdout, R>
+where
+    R: Render<T>,
+{
+    /// Starts the formatter with stdout.
+    #[allow(dead_code)]
+    pub fn start_stdout(render: R) -> Formatter<T, Stdout, R> {
+        Formatter::<T, Stdout, R>::start(stdout(), render)
+    }
+}
+
+impl<T, W, R> Formatter<T, W, R>
+where
+    W: Write,
+    R: Render<T>,
+{
+    /// Starts the formatter with any struct that implements write.
+    pub fn start(writer: W, render: R) -> Formatter<T, W, R>
+    where
+        W: Write,
+        R: Render<T>,
+    {
+        Formatter {
+            writer,
+            render,
+            _marker: marker::PhantomData,
+        }._start()
+    }
+
+    fn _start(mut self) -> Self {
+        if let Some(output) = self.render.preamble() {
+            writeln!(&mut self.writer, "{}", output).expect("Failed writing to writer");
+        }
+        self
+    }
+
+    pub fn render(&mut self, item: &T) {
+        if let Some(output) = self.render.render(item) {
+            writeln!(&mut self.writer, "{}", output).expect("Failed writing to writer");
+        }
+    }
+
+    pub fn stop(mut self) -> W {
+        if let Some(output) = self.render.postamble() {
+            writeln!(&mut self.writer, "{}", output).expect("Failed writing to writer");
+        }
+        self.writer
+    }
+}
+
+#[cfg(test)]
+mod render_tests {
+    use super::*;
+
+    use std::io::Cursor;
+
+    struct Data {
+        a: String,
+        b: usize,
+    }
+
+    struct CSV;
+
+    impl Render<Data> for CSV {
+        fn preamble(&self) -> Option<String> {
+            Some(String::from("a,b"))
+        }
+
+        fn render(&self, item: &Data) -> Option<String> {
+            Some(format!("\"{}\",{}", item.a, item.b))
+        }
+    }
+
+    #[test]
+    fn renders_the_data() {
+        let data = vec![
+            Data {
+                a: String::from("s1"),
+                b: 1,
+            },
+            Data {
+                a: String::from("s2"),
+                b: 2,
+            },
+            Data {
+                a: String::from("s3"),
+                b: 3,
+            },
+        ];
+        let cursor = Cursor::new(Vec::new());
+        let mut render = Formatter::start(cursor, CSV);
+        for datum in data {
+            render.render(&datum)
+        }
+        let cursor = render.stop();
+        let output = String::from_utf8(cursor.into_inner()).unwrap();
+        assert_eq!(
+            r#"a,b
+"s1",1
+"s2",2
+"s3",3
+"#,
+            output
+        );
+    }
+}

--- a/cli/src/fmt/simple/account.rs
+++ b/cli/src/fmt/simple/account.rs
@@ -1,0 +1,12 @@
+use fmt::Render;
+use super::Simple;
+use stellar_client::resources::Account;
+
+impl Render<Account> for Simple {
+    fn render(&self, account: &Account) -> Option<String> {
+        let mut buf = String::new();
+        buf.push_str(&format!("ID:       {}\n", account.id()));
+        buf.push_str(&format!("Sequence: {}\n", account.sequence()));
+        Some(buf)
+    }
+}

--- a/cli/src/fmt/simple/asset.rs
+++ b/cli/src/fmt/simple/asset.rs
@@ -1,0 +1,30 @@
+use fmt::Render;
+use super::Simple;
+use stellar_client::resources::Asset;
+
+impl Render<Asset> for Simple {
+    fn render(&self, asset: &Asset) -> Option<String> {
+        let mut buf = String::new();
+
+        macro_rules! append {
+            ($($args:tt)*) => {
+                buf.push_str(&format!($($args)*));
+                buf.push_str("\n");
+            }
+        }
+
+        append!("Code:         {}", asset.code());
+        append!("Type:         {}", asset.asset_type());
+        append!("Issuer:       {}", asset.issuer());
+        append!("Amount:       {}", asset.amount());
+        append!("Num accounts: {}", asset.num_accounts());
+        append!("Flags:");
+        if asset.is_auth_required() {
+            append!("  auth is required");
+        }
+        if asset.is_auth_revocable() {
+            append!("  auth is revocable");
+        }
+        Some(buf)
+    }
+}

--- a/cli/src/fmt/simple/mod.rs
+++ b/cli/src/fmt/simple/mod.rs
@@ -1,0 +1,4 @@
+pub struct Simple;
+
+mod account;
+mod asset;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,6 +15,7 @@ mod error;
 mod ledgers;
 mod ordering;
 mod pager;
+mod fmt;
 mod trades;
 mod transactions;
 


### PR DESCRIPTION
To simplify the rendering process I've created a way to implement the
render trait for a given resource. This can then be entirely inferred in
the cli commands. In theory, we could have `Simple`, `Color`, `CSV` as
various "types" to implement render on. Then if it's implemented the cli
will just work.

I've only implemented a couple of the resources, the rest can be built as we go.

fixes #121 

### Is there a GIF that reflects how this work made you feel?
![chuck-norris-super-kick](https://user-images.githubusercontent.com/2043529/39280263-286ac76a-48b3-11e8-831a-709cb763eb9d.gif)
