### PR TITLE
Define append macro once for simple formatter

### DIFF
--- a/cli/src/fmt/simple/account.rs
+++ b/cli/src/fmt/simple/account.rs
@@ -5,8 +5,8 @@ use stellar_client::resources::Account;
 impl Render<Account> for Simple {
     fn render(&self, account: &Account) -> Option<String> {
         let mut buf = String::new();
-        buf.push_str(&format!("ID:       {}\n", account.id()));
-        buf.push_str(&format!("Sequence: {}\n", account.sequence()));
+        append_to_buffer!(buf, "ID:       {}", account.id());
+        append_to_buffer!(buf, "Sequence: {}", account.sequence());
         Some(buf)
     }
 }

--- a/cli/src/fmt/simple/asset.rs
+++ b/cli/src/fmt/simple/asset.rs
@@ -5,25 +5,17 @@ use stellar_client::resources::Asset;
 impl Render<Asset> for Simple {
     fn render(&self, asset: &Asset) -> Option<String> {
         let mut buf = String::new();
-
-        macro_rules! append {
-            ($($args:tt)*) => {
-                buf.push_str(&format!($($args)*));
-                buf.push_str("\n");
-            }
-        }
-
-        append!("Code:         {}", asset.code());
-        append!("Type:         {}", asset.asset_type());
-        append!("Issuer:       {}", asset.issuer());
-        append!("Amount:       {}", asset.amount());
-        append!("Num accounts: {}", asset.num_accounts());
-        append!("Flags:");
+        append_to_buffer!(buf, "Code:         {}", asset.code());
+        append_to_buffer!(buf, "Type:         {}", asset.asset_type());
+        append_to_buffer!(buf, "Issuer:       {}", asset.issuer());
+        append_to_buffer!(buf, "Amount:       {}", asset.amount());
+        append_to_buffer!(buf, "Num accounts: {}", asset.num_accounts());
+        append_to_buffer!(buf, "Flags:");
         if asset.is_auth_required() {
-            append!("  auth is required");
+            append_to_buffer!(buf, "  auth is required");
         }
         if asset.is_auth_revocable() {
-            append!("  auth is revocable");
+            append_to_buffer!(buf, "  auth is revocable");
         }
         Some(buf)
     }

--- a/cli/src/fmt/simple/mod.rs
+++ b/cli/src/fmt/simple/mod.rs
@@ -1,6 +1,25 @@
+#![macro_use]
+macro_rules! append_to_buffer {
+    ($buffer:expr, $($args:tt)*) => {
+        $buffer.push_str(&format!($($args)*));
+        $buffer.push_str("\n");
+    }
+}
 pub struct Simple;
 
 mod account;
 mod asset;
 mod trade_aggregation;
 mod transaction;
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn it_appends_to_a_buffer() {
+        let mut buffer = String::new();
+        append_to_buffer!(buffer, "Fantastic Mr Fox");
+
+        assert_eq!(buffer, "Fantastic Mr Fox\n".to_string());
+    }
+}

--- a/cli/src/fmt/simple/trade_aggregation.rs
+++ b/cli/src/fmt/simple/trade_aggregation.rs
@@ -5,22 +5,15 @@ use stellar_client::resources::TradeAggregation;
 impl Render<TradeAggregation> for Simple {
     fn render(&self, aggregation: &TradeAggregation) -> Option<String> {
         let mut buf = String::new();
-
-        macro_rules! append {
-            ($($args:tt)*) => {
-                buf.push_str(&format!($($args)*));
-                buf.push_str("\n");
-            }
-        }
-        append!("timestamp:      {}", aggregation.started_at());
-        append!("trade_count:    {}", aggregation.count());
-        append!("base_volume:    {}", aggregation.base_volume());
-        append!("counter_volume: {}", aggregation.counter_volume());
-        append!("average:        {}", aggregation.average());
-        append!("high:           {}", aggregation.high());
-        append!("low:            {}", aggregation.low());
-        append!("open:           {}", aggregation.open());
-        append!("close:          {}", aggregation.close());
+        append_to_buffer!(buf, "timestamp:      {}", aggregation.started_at());
+        append_to_buffer!(buf, "trade_count:    {}", aggregation.count());
+        append_to_buffer!(buf, "base_volume:    {}", aggregation.base_volume());
+        append_to_buffer!(buf, "counter_volume: {}", aggregation.counter_volume());
+        append_to_buffer!(buf, "average:        {}", aggregation.average());
+        append_to_buffer!(buf, "high:           {}", aggregation.high());
+        append_to_buffer!(buf, "low:            {}", aggregation.low());
+        append_to_buffer!(buf, "open:           {}", aggregation.open());
+        append_to_buffer!(buf, "close:          {}", aggregation.close());
         Some(buf)
     }
 }

--- a/cli/src/fmt/simple/transaction.rs
+++ b/cli/src/fmt/simple/transaction.rs
@@ -5,16 +5,9 @@ use stellar_client::resources::Transaction;
 impl Render<Transaction> for Simple {
     fn render(&self, txn: &Transaction) -> Option<String> {
         let mut buf = String::new();
-
-        macro_rules! append {
-            ($($args:tt)*) => {
-                buf.push_str(&format!($($args)*));
-                buf.push_str("\n");
-            }
-        }
-        append!("ID:             {}", txn.id());
-        append!("source account: {}", txn.source_account());
-        append!("created at:     {}", txn.created_at());
+        append_to_buffer!(buf, "ID:             {}", txn.id());
+        append_to_buffer!(buf, "source account: {}", txn.source_account());
+        append_to_buffer!(buf, "created at:     {}", txn.created_at());
 
         Some(buf)
     }


### PR DESCRIPTION
Each formatter was defining its own append macro.  This commit extracts
that macro into /fmt/simple/mod.rs to DRY up those definitions.

### Is there a GIF that reflects how this work made you feel?
![Alt Text](https://media.giphy.com/media/sPvqJVzs2HCg0/giphy.gif)

