### PR TITLE
Add all payments to CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,7 @@ mod ledgers;
 mod ordering;
 mod pager;
 mod resolution;
+mod payments;
 mod trades;
 mod transactions;
 
@@ -182,6 +183,17 @@ fn build_app<'a, 'b>() -> App<'a, 'b> {
                     )
                 )
         )
+         .subcommand(
+            SubCommand::with_name("payments")
+                .about("Access lists of payments")
+                .setting(AppSettings::SubcommandRequired)
+                .subcommand(
+                    listable!(
+                        SubCommand::with_name("all")
+                            .about("Fetch all payments")
+                    ),
+                )
+        )
         .subcommand(
             SubCommand::with_name("trades")
                 .about("Access lists of trades")
@@ -333,6 +345,10 @@ fn main() {
         ("ledgers", Some(sub_m)) => match sub_m.subcommand() {
             ("all", Some(sub_m)) => ledgers::all(&client, sub_m),
             ("payments", Some(sub_m)) => ledgers::payments(&client, sub_m),
+            _ => return print_help_and_exit(),
+        },
+        ("payments", Some(sub_m)) => match sub_m.subcommand() {
+            ("all", Some(sub_m)) => payments::all(&client, sub_m),
             _ => return print_help_and_exit(),
         },
         ("trades", Some(sub_m)) => match sub_m.subcommand() {

--- a/cli/src/payments.rs
+++ b/cli/src/payments.rs
@@ -1,4 +1,4 @@
-use stellar_client::{endpoint::ledger, resources::OperationKind, sync::{self, Client}};
+use stellar_client::{endpoint::payment, resources::OperationKind, sync::{self, Client}};
 use clap::ArgMatches;
 use error::Result;
 use super::{cursor, ordering, pager::Pager};
@@ -6,38 +6,7 @@ use super::{cursor, ordering, pager::Pager};
 pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);
 
-    let endpoint = ledger::All::default();
-    let endpoint = pager.assign(endpoint);
-    let endpoint = cursor::assign_from_arg(matches, endpoint);
-    let endpoint = ordering::assign_from_arg(matches, endpoint);
-
-    let iter = sync::Iter::new(&client, endpoint);
-
-    let mut res = Ok(());
-    pager.paginate(iter, |result| match result {
-        Ok(ledger) => {
-            println!("hash:              {}", ledger.hash());
-            println!("sequence:          {}", ledger.sequence());
-            println!("transaction count: {}", ledger.transaction_count());
-            println!("operation count:   {}", ledger.operation_count());
-            println!("closed at:         {}", ledger.closed_at());
-            println!();
-        }
-        Err(err) => res = Err(err.into()),
-    });
-    res
-}
-
-pub fn payments(client: &Client, matches: &ArgMatches) -> Result<()> {
-    let pager = Pager::from_arg(&matches);
-    let sequence = matches
-        .value_of("sequence")
-        .expect("Ledger sequence is required");
-
-    let sequence = sequence
-        .parse::<u32>()
-        .map_err(|_| String::from("Payment sequence should be a valid u32 integer"))?;
-    let endpoint = ledger::Payments::new(sequence);
+    let endpoint = payment::All::default();
     let endpoint = pager.assign(endpoint);
     let endpoint = cursor::assign_from_arg(matches, endpoint);
     let endpoint = ordering::assign_from_arg(matches, endpoint);
@@ -68,18 +37,6 @@ pub fn payments(client: &Client, matches: &ArgMatches) -> Result<()> {
                     println!("Operation Kind:           Path Payment");
                     println!("To account:               {}", path_payment.to());
                     println!("From account:             {}", path_payment.from());
-                    println!(
-                        "Source Asset Type:        {}",
-                        path_payment.source_asset().asset_type()
-                    );
-                    println!(
-                        "Source Asset Code:        {}",
-                        path_payment.source_asset().code()
-                    );
-                    println!(
-                        "Source Asset Issuer:      {}",
-                        path_payment.source_asset().issuer()
-                    );
                     println!(
                         "Destination Asset Type:   {}",
                         path_payment.destination_asset().asset_type()

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -73,7 +73,6 @@ pub fn payments(client: &Client, matches: &ArgMatches) -> Result<()> {
                         "Source Asset Issuer:      {}",
                         path_payment.source_asset().issuer()
                     );
-                    println!("Source Amount:            {}", path_payment.source_amount());
                     println!(
                         "Destination Asset Type:   {}",
                         path_payment.destination_asset().asset_type()

--- a/client/fixtures/operations/path_payment.json
+++ b/client/fixtures/operations/path_payment.json
@@ -27,7 +27,6 @@
   "source_asset_code": "USD",
   "source_asset_issuer": "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
   "source_asset_type": "credit_alphanum4",
-  "source_amount": "10.0",
   "source_max": "10.0",
   "to": "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
   "type_i": 2,

--- a/client/src/resources/operation/mod.rs
+++ b/client/src/resources/operation/mod.rs
@@ -314,7 +314,6 @@ impl<'de> Deserialize<'de> for Operation {
                     source_asset_code,
                     source_asset_issuer,
                     source_asset_type: Some(source_asset_type),
-                    source_amount: Some(source_amount),
                     source_max: Some(source_max),
                     ..
                 } => {
@@ -332,7 +331,6 @@ impl<'de> Deserialize<'de> for Operation {
                         destination_asset_identifier,
                         amount,
                         source_asset_identifier,
-                        source_amount,
                         source_max,
                     ))
                 }

--- a/client/src/resources/operation/path_payment.rs
+++ b/client/src/resources/operation/path_payment.rs
@@ -11,7 +11,6 @@ pub struct PathPayment {
     destination_amount: Amount,
     source_asset: AssetIdentifier,
     source_max: Amount,
-    source_amount: Amount,
 }
 
 impl PathPayment {
@@ -23,7 +22,6 @@ impl PathPayment {
         destination_amount: Amount,
         source_asset: AssetIdentifier,
         source_max: Amount,
-        source_amount: Amount,
     ) -> PathPayment {
         PathPayment {
             from,
@@ -31,7 +29,6 @@ impl PathPayment {
             destination_asset,
             destination_amount,
             source_asset,
-            source_amount,
             source_max,
         }
     }
@@ -58,11 +55,6 @@ impl PathPayment {
     /// Asset at the source of payment path.
     pub fn source_asset(&self) -> &AssetIdentifier {
         &self.source_asset
-    }
-
-    /// Amount sent.
-    pub fn source_amount(&self) -> Amount {
-        self.source_amount
     }
 
     /// Max send amount.

--- a/client/src/resources/operation/test.rs
+++ b/client/src/resources/operation/test.rs
@@ -237,7 +237,6 @@ fn it_parses_a_path_payment_from_json() {
             Amount::new(100_000_000)
         );
         assert_eq!(account_details.source_asset().code(), "USD");
-        assert_eq!(account_details.source_amount(), Amount::new(100_000_000));
         assert_eq!(account_details.source_max(), Amount::new(100_000_000));
     } else {
         panic!("Did not generate path payment kind");


### PR DESCRIPTION
So I'll admit there is some nice copy-pasta here -- this is very similar to the ledgers payments cli.

However, I did find an error in the current CLI payments (found in both the ledgers and transactions). If you scrolled through until you found a path_payment, you would see that you get the error:

> Missing fields for path_payment operation.

The reason for this is that `source_amount` does not exist for path payments. See here:

https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=single&values=eyJ0cmFuc2FjdGlvbiI6IjAwNzk0ZGUyYmQxYzEyMTliMzUyNjU3YmNlMWU0ZDhjZTJmNjA3MzdiYzU1OGZmM2MwNDZiMTRkZTRhYWExMGQifQ%3D%3D&network=public

This field only exists on payment paths, an object describing an intermediate step on a path_payment.

### Is there a GIF that reflects how this work made you feel?
![https://media.giphy.com/media/yj5UdA4elp8Wc/giphy.gif](https://media.giphy.com/media/yj5UdA4elp8Wc/giphy.gif)

Closes #167 
