### PR TITLE
All effects added to CLI

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - All trades can be seen
 - Ledger payments can be seen
 - Trade aggregations can be seen
+- All effects can be seen

--- a/cli/src/effects.rs
+++ b/cli/src/effects.rs
@@ -1,0 +1,26 @@
+use stellar_client::{endpoint::effect, sync::{self, Client}};
+use clap::ArgMatches;
+use super::{cursor, ordering, pager::Pager};
+use error::Result;
+use fmt::{Formatter, Simple};
+
+/// Using a client and the arguments from the command line, iterates over the results
+/// and displays them to the end user.
+pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
+    let pager = Pager::from_arg(&matches);
+
+    let endpoint = effect::All::default();
+    let endpoint = pager.assign(endpoint);
+    let endpoint = cursor::assign_from_arg(matches, endpoint);
+    let endpoint = ordering::assign_from_arg(matches, endpoint);
+
+    let iter = sync::Iter::new(&client, endpoint);
+
+    let mut res = Ok(());
+    let mut fmt = Formatter::start_stdout(Simple);
+    pager.paginate(iter, |result| match result {
+        Ok(effect) => fmt.render(&effect),
+        Err(err) => res = Err(err.into()),
+    });
+    res
+}

--- a/cli/src/fmt/simple/effect.rs
+++ b/cli/src/fmt/simple/effect.rs
@@ -1,0 +1,179 @@
+use fmt::Render;
+use super::Simple;
+use stellar_client::resources::{AssetIdentifier, effect::{Effect, EffectKind as Kind}};
+
+impl Render<Effect> for Simple {
+    fn render(&self, effect: &Effect) -> Option<String> {
+        let mut buf = String::new();
+
+        append_to_buffer!(buf, "id:   {}", effect.id());
+        append_to_buffer!(buf, "kind: {}", effect.kind_name());
+        append_to_buffer!(buf, "details:");
+
+        Some(match *effect.kind() {
+            Kind::Account(ref kind) => account::render(buf, kind),
+            Kind::Signer(ref kind) => signer::render(buf, kind),
+            Kind::Trustline(ref kind) => trustline::render(buf, kind),
+            Kind::Trade(ref kind) => trade::render(buf, kind),
+            Kind::Data(ref kind) => data::render(buf, kind),
+        })
+    }
+}
+
+fn render_asset(id: &AssetIdentifier) -> String {
+    if id.is_native() {
+        id.code().to_string()
+    } else {
+        format!("{}-{}", id.code(), id.issuer())
+    }
+}
+
+mod account {
+    use super::*;
+    use stellar_client::resources::effect::account::Kind;
+
+    pub fn render(mut buf: String, kind: &Kind) -> String {
+        match *kind {
+            Kind::Created(ref effect) => {
+                append_to_buffer!(buf, "  account:          {}", effect.account());
+                append_to_buffer!(buf, "  starting_balance: {}", effect.starting_balance());
+            }
+            Kind::Credited(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+                append_to_buffer!(buf, "  asset:   {}", render_asset(effect.asset()));
+                append_to_buffer!(buf, "  amount:  {}", effect.amount());
+            }
+            Kind::Removed(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+            }
+            Kind::Debited(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+                append_to_buffer!(buf, "  asset:   {}", render_asset(effect.asset()));
+                append_to_buffer!(buf, "  amount:  {}", effect.amount());
+            }
+            Kind::ThresholdsUpdated(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+                append_to_buffer!(buf, "  low:     {}", effect.low());
+                append_to_buffer!(buf, "  med:     {}", effect.med());
+                append_to_buffer!(buf, "  high:    {}", effect.high());
+            }
+            Kind::HomeDomainUpdated(ref effect) => {
+                append_to_buffer!(buf, "  account:     {}", effect.account());
+                append_to_buffer!(buf, "  home domain: {}", effect.home_domain());
+            }
+            Kind::FlagsUpdated(ref effect) => {
+                append_to_buffer!(buf, "  account:     {}", effect.account());
+                append_to_buffer!(buf, "  flags:");
+                if effect.flags().is_auth_required() {
+                    append_to_buffer!(buf, "    auth is required");
+                }
+                if effect.flags().is_auth_revocable() {
+                    append_to_buffer!(buf, "    auth is revocable");
+                }
+            }
+        }
+        buf
+    }
+}
+
+mod signer {
+    use stellar_client::resources::effect::signer::Kind;
+
+    pub fn render(mut buf: String, kind: &Kind) -> String {
+        match *kind {
+            Kind::Created(ref effect) => {
+                append_to_buffer!(buf, "  account:    {}", effect.account());
+                append_to_buffer!(buf, "  public key: {}", effect.public_key());
+                append_to_buffer!(buf, "  weight:     {}", effect.weight());
+            }
+            Kind::Removed(ref effect) => {
+                append_to_buffer!(buf, "  account:    {}", effect.account());
+                append_to_buffer!(buf, "  public key: {}", effect.public_key());
+                append_to_buffer!(buf, "  weight:     {}", effect.weight());
+            }
+            Kind::Updated(ref effect) => {
+                append_to_buffer!(buf, "  account:    {}", effect.account());
+                append_to_buffer!(buf, "  public key: {}", effect.public_key());
+                append_to_buffer!(buf, "  weight:     {}", effect.weight());
+            }
+        }
+        buf
+    }
+}
+
+mod trustline {
+    use super::*;
+    use stellar_client::resources::effect::trustline::Kind;
+
+    pub fn render(mut buf: String, kind: &Kind) -> String {
+        match *kind {
+            Kind::Authorized(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+                append_to_buffer!(buf, "  asset:   {}", render_asset(effect.asset()));
+            }
+            Kind::Deauthorized(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+                append_to_buffer!(buf, "  asset:   {}", render_asset(effect.asset()));
+            }
+            Kind::Removed(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+                append_to_buffer!(buf, "  limit:   {}", effect.limit());
+                append_to_buffer!(buf, "  asset:   {}", render_asset(effect.asset()));
+            }
+            Kind::Updated(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+                append_to_buffer!(buf, "  limit:   {}", effect.limit());
+                append_to_buffer!(buf, "  asset:   {}", render_asset(effect.asset()));
+            }
+            Kind::Created(ref effect) => {
+                append_to_buffer!(buf, "  account: {}", effect.account());
+                append_to_buffer!(buf, "  limit:   {}", effect.limit());
+                append_to_buffer!(buf, "  asset:   {}", render_asset(effect.asset()));
+            }
+        }
+        buf
+    }
+}
+
+mod trade {
+    use super::*;
+    use stellar_client::resources::effect::trade::Kind;
+
+    pub fn render(mut buf: String, kind: &Kind) -> String {
+        match *kind {
+            Kind::Trade(ref effect) => {
+                append_to_buffer!(buf, "  account:      {}", effect.account());
+                append_to_buffer!(buf, "  seller:       {}", effect.seller());
+                append_to_buffer!(buf, "  offer id:     {}", effect.offer_id());
+                append_to_buffer!(buf, "  sold amount:  {}", effect.sold_amount());
+                append_to_buffer!(buf, "  sold asset:   {}", render_asset(effect.sold_asset()));
+                append_to_buffer!(buf, "  bough amount: {}", effect.bought_amount());
+                append_to_buffer!(
+                    buf,
+                    "  bought asset: {}",
+                    render_asset(effect.bought_asset())
+                );
+            }
+        }
+        buf
+    }
+}
+
+mod data {
+    use stellar_client::resources::effect::data::Kind;
+
+    pub fn render(mut buf: String, kind: &Kind) -> String {
+        match *kind {
+            Kind::Created(ref effect) => {
+                append_to_buffer!(buf, "  account:    {}", effect.account());
+            }
+            Kind::Removed(ref effect) => {
+                append_to_buffer!(buf, "  account:    {}", effect.account());
+            }
+            Kind::Updated(ref effect) => {
+                append_to_buffer!(buf, "  account:    {}", effect.account());
+            }
+        }
+        buf
+    }
+}

--- a/cli/src/fmt/simple/mod.rs
+++ b/cli/src/fmt/simple/mod.rs
@@ -9,6 +9,7 @@ pub struct Simple;
 
 mod account;
 mod asset;
+mod effect;
 mod ledger;
 mod trade_aggregation;
 mod transaction;

--- a/cli/src/ledgers.rs
+++ b/cli/src/ledgers.rs
@@ -44,14 +44,14 @@ pub fn payments(client: &Client, matches: &ArgMatches) -> Result<()> {
     pager.paginate(iter, |result| match result {
         Ok(op) => {
             println!("ID:             {}", op.id());
-            match op.kind() {
-                &OperationKind::CreateAccount(ref create_account) => {
+            match *op.kind() {
+                OperationKind::CreateAccount(ref create_account) => {
                     println!("Operation Kind:   Create Account");
                     println!("Account:          {}", create_account.account());
                     println!("Funder:           {}", create_account.funder());
                     println!("Starting Balance: {}", create_account.starting_balance());
                 }
-                &OperationKind::Payment(ref payment) => {
+                OperationKind::Payment(ref payment) => {
                     println!("Operation Kind: Payment");
                     println!("To account:     {}", payment.to());
                     println!("From account:   {}", payment.from());
@@ -60,7 +60,7 @@ pub fn payments(client: &Client, matches: &ArgMatches) -> Result<()> {
                     println!("Asset Issuer:   {}", payment.asset().issuer());
                     println!("Amount:         {}", payment.amount());
                 }
-                &OperationKind::PathPayment(ref path_payment) => {
+                OperationKind::PathPayment(ref path_payment) => {
                     println!("Operation Kind:           Path Payment");
                     println!("To account:               {}", path_payment.to());
                     println!("From account:             {}", path_payment.from());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,7 @@ use error::CliError;
 mod account;
 mod assets;
 mod cursor;
+mod effects;
 mod error;
 mod fmt;
 mod ledgers;
@@ -81,6 +82,17 @@ fn build_app<'a, 'b>() -> App<'a, 'b> {
                     ),
 
                 ),
+        )
+        .subcommand(
+            SubCommand::with_name("effects")
+                .about("Access lists of effects")
+                .setting(AppSettings::SubcommandRequired)
+                .subcommand(
+                    listable!(
+                        SubCommand::with_name("all")
+                            .about("Fetch all effects")
+                    )
+                )
         )
         .subcommand(
             SubCommand::with_name("transactions")
@@ -318,16 +330,12 @@ fn main() {
             ("transactions", Some(sub_m)) => account::transactions(&client, sub_m),
             _ => return print_help_and_exit(),
         },
-        ("transactions", Some(sub_m)) => match sub_m.subcommand() {
-            ("all", Some(sub_m)) => transactions::all(&client, sub_m),
-            ("details", Some(sub_m)) => transactions::details(&client, sub_m),
-            ("operations", Some(sub_m)) => transactions::operations(&client, sub_m),
-            ("payments", Some(sub_m)) => transactions::payments(&client, sub_m),
-            ("effects", Some(sub_m)) => transactions::effects(&client, sub_m),
-            _ => return print_help_and_exit(),
-        },
         ("assets", Some(sub_m)) => match sub_m.subcommand() {
             ("all", Some(sub_m)) => assets::all(&client, sub_m),
+            _ => return print_help_and_exit(),
+        },
+        ("effects", Some(sub_m)) => match sub_m.subcommand() {
+            ("all", Some(sub_m)) => effects::all(&client, sub_m),
             _ => return print_help_and_exit(),
         },
         ("ledgers", Some(sub_m)) => match sub_m.subcommand() {
@@ -338,6 +346,14 @@ fn main() {
         ("trades", Some(sub_m)) => match sub_m.subcommand() {
             ("aggregations", Some(sub_m)) => trades::aggregations(&client, sub_m),
             ("all", Some(sub_m)) => trades::all(&client, sub_m),
+            _ => return print_help_and_exit(),
+        },
+        ("transactions", Some(sub_m)) => match sub_m.subcommand() {
+            ("all", Some(sub_m)) => transactions::all(&client, sub_m),
+            ("details", Some(sub_m)) => transactions::details(&client, sub_m),
+            ("operations", Some(sub_m)) => transactions::operations(&client, sub_m),
+            ("payments", Some(sub_m)) => transactions::payments(&client, sub_m),
+            ("effects", Some(sub_m)) => transactions::effects(&client, sub_m),
             _ => return print_help_and_exit(),
         },
         _ => return print_help_and_exit(),

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -41,14 +41,14 @@ pub fn payments(client: &Client, matches: &ArgMatches) -> Result<()> {
     pager.paginate(iter, |result| match result {
         Ok(op) => {
             println!("ID:             {}", op.id());
-            match op.kind() {
-                &OperationKind::CreateAccount(ref create_account) => {
+            match *op.kind() {
+                OperationKind::CreateAccount(ref create_account) => {
                     println!("Operation Kind:   Create Account");
                     println!("Account:          {}", create_account.account());
                     println!("Funder:           {}", create_account.funder());
                     println!("Starting Balance: {}", create_account.starting_balance());
                 }
-                &OperationKind::Payment(ref payment) => {
+                OperationKind::Payment(ref payment) => {
                     println!("Operation Kind: Payment");
                     println!("To account:     {}", payment.to());
                     println!("From account:   {}", payment.from());
@@ -57,7 +57,7 @@ pub fn payments(client: &Client, matches: &ArgMatches) -> Result<()> {
                     println!("Asset Issuer:   {}", payment.asset().issuer());
                     println!("Amount:         {}", payment.amount());
                 }
-                &OperationKind::PathPayment(ref path_payment) => {
+                OperationKind::PathPayment(ref path_payment) => {
                     println!("Operation Kind:           Path Payment");
                     println!("To account:               {}", path_payment.to());
                     println!("From account:             {}", path_payment.from());

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Updated Flags to be public (and plural) so that it's accessible in the effects.
+- Added data effects to the resources module. These are undocumented in the stellar resource online but appear in the all effects endpoint.
+
 ## [0.1.0] - 2018-04-20
 
 ### Added

--- a/client/fixtures/effects/data_created.json
+++ b/client/fixtures/effects/data_created.json
@@ -1,0 +1,18 @@
+{
+  "_links": {
+    "operation": {
+      "href": "https://horizon-testnet.stellar.org/operations/37326362473689125"
+    },
+    "succeeds": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=37326362473689125-1"
+    },
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=37326362473689125-1"
+    }
+  },
+  "id": "0037326362473689125-0000000001",
+  "paging_token": "37326362473689125-1",
+  "account": "GDWGJSTUVRNFTR7STPUUHFWQYAN6KBVWCZT2YN7MY276GCSSXSWPS6JY",
+  "type": "data_created",
+  "type_i": 40
+}

--- a/client/fixtures/effects/data_removed.json
+++ b/client/fixtures/effects/data_removed.json
@@ -1,0 +1,18 @@
+{
+  "_links": {
+    "operation": {
+      "href": "https://horizon-testnet.stellar.org/operations/37326362473689125"
+    },
+    "succeeds": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=37326362473689125-1"
+    },
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=37326362473689125-1"
+    }
+  },
+  "id": "0037326362473689125-0000000001",
+  "paging_token": "37326362473689125-1",
+  "account": "GDWGJSTUVRNFTR7STPUUHFWQYAN6KBVWCZT2YN7MY276GCSSXSWPS6JY",
+  "type": "data_removed",
+  "type_i": 41
+}

--- a/client/fixtures/effects/data_updated.json
+++ b/client/fixtures/effects/data_updated.json
@@ -1,0 +1,18 @@
+{
+  "_links": {
+    "operation": {
+      "href": "https://horizon-testnet.stellar.org/operations/37326362473689125"
+    },
+    "succeeds": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=37326362473689125-1"
+    },
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=37326362473689125-1"
+    }
+  },
+  "id": "0037326362473689125-0000000001",
+  "paging_token": "37326362473689125-1",
+  "account": "GDWGJSTUVRNFTR7STPUUHFWQYAN6KBVWCZT2YN7MY276GCSSXSWPS6JY",
+  "type": "data_updated",
+  "type_i": 42
+}

--- a/client/src/resources/effect/account/flags_updated.rs
+++ b/client/src/resources/effect/account/flags_updated.rs
@@ -1,15 +1,15 @@
-use resources::asset::Flag;
+use resources::asset::Flags;
 /// This effect can be the result of a set options operation and represents
 /// the fact that an account's flags have been updated
 #[derive(Debug, Deserialize, Clone)]
 pub struct FlagsUpdated {
     account: String,
-    flags: Flag,
+    flags: Flags,
 }
 
 impl FlagsUpdated {
     /// Creates a new FlagsUpdated effect
-    pub fn new(account: String, flags: Flag) -> FlagsUpdated {
+    pub fn new(account: String, flags: Flags) -> FlagsUpdated {
         FlagsUpdated { account, flags }
     }
 
@@ -19,7 +19,7 @@ impl FlagsUpdated {
     }
 
     /// The flags for an account after the operations have taken place
-    pub fn flags(&self) -> Flag {
+    pub fn flags(&self) -> Flags {
         self.flags
     }
 }

--- a/client/src/resources/effect/data.rs
+++ b/client/src/resources/effect/data.rs
@@ -1,0 +1,29 @@
+//! Contains effects related to the management of data.
+
+/// The type of change that was performed
+#[derive(Debug, Deserialize, Clone)]
+pub enum Kind {
+    /// Data was added to an account.
+    Created(Effect),
+    /// Data was removed from an account.
+    Removed(Effect),
+    /// Data was modified on an account.
+    Updated(Effect),
+}
+
+/// Contains details about the data that was changed
+#[derive(Debug, Deserialize, Clone)]
+pub struct Effect {
+    account: String,
+}
+
+impl Effect {
+    /// Creates a new Account
+    pub fn new(account: String) -> Self {
+        Self { account }
+    }
+    /// The public address of a new account that was funded.
+    pub fn account(&self) -> &str {
+        &self.account
+    }
+}

--- a/client/src/resources/effect/test.rs
+++ b/client/src/resources/effect/test.rs
@@ -1,7 +1,7 @@
-use resources::{Amount, asset::Flag,
+use resources::{Amount, asset::Flags,
                 effect::{Effect, EffectKind, account::Kind as AccountKind,
-                         signer::Kind as SignerKind, trade::Kind as TradeKind,
-                         trustline::Kind as TrustlineKind}};
+                         data::Kind as DataKind, signer::Kind as SignerKind,
+                         trade::Kind as TradeKind, trustline::Kind as TrustlineKind}};
 use serde_json;
 
 fn account_created_json() -> &'static str {
@@ -140,9 +140,67 @@ fn it_parses_account_flags_updated_from_json() {
             effect_details.account(),
             "GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO"
         );
-        assert_eq!(effect_details.flags(), Flag::new(false, true));
+        assert_eq!(effect_details.flags(), Flags::new(false, true));
     } else {
         panic!("Did not generate account flags updated kind");
+    }
+}
+
+mod data {
+    use super::*;
+
+    fn data_updated_json() -> &'static str {
+        include_str!("../../../fixtures/effects/data_updated.json")
+    }
+    #[test]
+    fn it_parses_data_updated_from_json() {
+        let effect: Effect = serde_json::from_str(&data_updated_json()).unwrap();
+        assert!(effect.is_data_updated());
+        assert_eq!(effect.type_i(), 42);
+        if let &EffectKind::Data(DataKind::Updated(ref effect_details)) = effect.kind() {
+            assert_eq!(
+                effect_details.account(),
+                "GDWGJSTUVRNFTR7STPUUHFWQYAN6KBVWCZT2YN7MY276GCSSXSWPS6JY"
+            );
+        } else {
+            panic!("Did not generate account flags removed kind: {:?}", effect);
+        }
+    }
+
+    fn data_created_json() -> &'static str {
+        include_str!("../../../fixtures/effects/data_created.json")
+    }
+    #[test]
+    fn it_parses_data_created_from_json() {
+        let effect: Effect = serde_json::from_str(&data_created_json()).unwrap();
+        assert!(effect.is_data_created());
+        assert_eq!(effect.type_i(), 40);
+        if let &EffectKind::Data(DataKind::Created(ref effect_details)) = effect.kind() {
+            assert_eq!(
+                effect_details.account(),
+                "GDWGJSTUVRNFTR7STPUUHFWQYAN6KBVWCZT2YN7MY276GCSSXSWPS6JY"
+            );
+        } else {
+            panic!("Did not generate account flags created kind: {:?}", effect);
+        }
+    }
+
+    fn data_removed_json() -> &'static str {
+        include_str!("../../../fixtures/effects/data_removed.json")
+    }
+    #[test]
+    fn it_parses_data_removed_from_json() {
+        let effect: Effect = serde_json::from_str(&data_removed_json()).unwrap();
+        assert!(effect.is_data_removed());
+        assert_eq!(effect.type_i(), 41);
+        if let &EffectKind::Data(DataKind::Removed(ref effect_details)) = effect.kind() {
+            assert_eq!(
+                effect_details.account(),
+                "GDWGJSTUVRNFTR7STPUUHFWQYAN6KBVWCZT2YN7MY276GCSSXSWPS6JY"
+            );
+        } else {
+            panic!("Did not generate account flags removed kind: {:?}", effect);
+        }
     }
 }
 
@@ -377,4 +435,7 @@ mod errors_on_missing_fields_for_effect_types {
     assert_err_on_missing_fields!(trustline_updated, 22);
     assert_err_on_missing_fields!(trustline_authorized, 23);
     assert_err_on_missing_fields!(trade, 33);
+    assert_err_on_missing_fields!(data_created, 40);
+    assert_err_on_missing_fields!(data_removed, 41);
+    assert_err_on_missing_fields!(data_updated, 42);
 }

--- a/client/src/resources/mod.rs
+++ b/client/src/resources/mod.rs
@@ -26,7 +26,7 @@ mod transaction;
 /// they can be used with a client. Either for reading or for writing.
 pub use self::account::Account;
 pub use self::amount::Amount;
-pub use self::asset::{Asset, AssetIdentifier};
+pub use self::asset::{Asset, AssetIdentifier, Flags};
 pub use self::datum::Datum;
 pub use self::effect::Effect;
 pub use self::ledger::Ledger;

--- a/client/src/resources/operation/mod.rs
+++ b/client/src/resources/operation/mod.rs
@@ -1,4 +1,4 @@
-use resources::{Amount, AssetIdentifier, asset::Flag, offer::PriceRatio};
+use resources::{Amount, AssetIdentifier, asset::Flags, offer::PriceRatio};
 use super::deserialize;
 use serde::{de, Deserialize, Deserializer};
 mod account_merge;
@@ -452,23 +452,23 @@ impl<'de> Deserialize<'de> for Operation {
                     home_domain: Some(home_domain),
                     ..
                 } => {
-                    let set_flags: Option<Flag> = match set_flags_s {
+                    let set_flags: Option<Flags> = match set_flags_s {
                         Some(vec_strings) => {
                             let auth_required =
                                 vec_strings.iter().any(|e| e == "auth_required_flag");
                             let auth_revocable =
                                 vec_strings.iter().any(|e| e == "auth_revocable_flag");
-                            Some(Flag::new(auth_required, auth_revocable))
+                            Some(Flags::new(auth_required, auth_revocable))
                         }
                         None => None,
                     };
-                    let clear_flags: Option<Flag> = match clear_flags_s {
+                    let clear_flags: Option<Flags> = match clear_flags_s {
                         Some(vec_strings) => {
                             let auth_required =
                                 vec_strings.iter().any(|e| e == "auth_required_flag");
                             let auth_revocable =
                                 vec_strings.iter().any(|e| e == "auth_revocable_flag");
-                            Some(Flag::new(auth_required, auth_revocable))
+                            Some(Flags::new(auth_required, auth_revocable))
                         }
                         None => None,
                     };

--- a/client/src/resources/operation/set_options.rs
+++ b/client/src/resources/operation/set_options.rs
@@ -1,4 +1,4 @@
-use resources::asset::Flag;
+use resources::asset::Flags;
 
 /// Use “Set Options” operation to set following options to your account:
 ///
@@ -17,8 +17,8 @@ pub struct SetOptions {
     master_key_weight: u8,
     thresholds: Thresholds,
     home_domain: String,
-    set_flags: Option<Flag>,
-    clear_flags: Option<Flag>,
+    set_flags: Option<Flags>,
+    clear_flags: Option<Flags>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -37,8 +37,8 @@ impl SetOptions {
         master_key_weight: u8,
         (low, med, high): (u32, u32, u32),
         home_domain: String,
-        set_flags: Option<Flag>,
-        clear_flags: Option<Flag>,
+        set_flags: Option<Flags>,
+        clear_flags: Option<Flags>,
     ) -> SetOptions {
         SetOptions {
             signer_key,
@@ -87,12 +87,12 @@ impl SetOptions {
     }
 
     /// The flags that have been set in this operation
-    pub fn set_flags(&self) -> Option<Flag> {
+    pub fn set_flags(&self) -> Option<Flags> {
         self.set_flags
     }
 
     /// The flags that have been cleared in this operation
-    pub fn clear_flags(&self) -> Option<Flag> {
+    pub fn clear_flags(&self) -> Option<Flags> {
         self.clear_flags
     }
 }

--- a/client/src/resources/operation/test.rs
+++ b/client/src/resources/operation/test.rs
@@ -1,5 +1,5 @@
 use serde_json;
-use resources::{Amount, Operation, OperationKind, asset::Flag};
+use resources::{Amount, Operation, OperationKind, asset::Flags};
 
 fn account_merge_json() -> &'static str {
     include_str!("../../../fixtures/operations/account_merge.json")
@@ -290,7 +290,10 @@ fn it_parses_a_set_options_from_json() {
         assert_eq!(account_details.high_threshold(), 3);
         assert_eq!(account_details.home_domain(), "stellar.org");
         assert!(account_details.clear_flags().is_none());
-        assert_eq!(account_details.set_flags().unwrap(), Flag::new(true, false));
+        assert_eq!(
+            account_details.set_flags().unwrap(),
+            Flags::new(true, false)
+        );
     } else {
         panic!("Did not generate set options kind");
     }


### PR DESCRIPTION
Implements the effects in the CLI. This actually uncovered a couple of
other things that needed to be refactored to work correctly.

First, `Flags` needed to be made public. In the process of exposing it I
renamed it to `Flags` from `Flag` since it contains multiple flags.

Second, there are three undocumented effects that needed to be
implemented. These include data_created, data_updated, and data_removed.

Lastly, the effects were added as a render to the cli.

### Is there a GIF that reflects how this work made you feel?
![hrmph](https://user-images.githubusercontent.com/2043529/39401867-ea69c5ca-4b04-11e8-98e7-9d4a82b5391c.gif)
