### PR TITLE
Refactor array pattern match

### DIFF
--- a/cli/src/asset_identifier.rs
+++ b/cli/src/asset_identifier.rs
@@ -3,25 +3,14 @@ use stellar_client::resources::AssetIdentifier;
 
 pub fn from_str(s: &str) -> Result<AssetIdentifier, InvalidInputError> {
     let tokens: Vec<&str> = s.split('-').collect();
-    if tokens.len() > 2 {
-        return Err(InvalidInputError::from_str(
-            "Asset identifier not of the form <asset_code>-<asset_issuer>",
-        ));
-    }
 
-    match (tokens.get(0), tokens.get(1)) {
-        (Some(&"XLM"), None) => return Ok(AssetIdentifier::Native),
-        (Some(code), Some(issuer)) if code.len() <= 4 => {
-            return Ok(AssetIdentifier::alphanum4(code, issuer))
-        }
-        (Some(code), Some(issuer)) if code.len() <= 12 => {
-            return Ok(AssetIdentifier::alphanum12(code, issuer))
-        }
-        _ => {
-            return Err(InvalidInputError::from_str(
-                "Asset identifier not of the form <asset_code>-<asset_issuer>",
-            ))
-        }
+    match &tokens[..] {
+        ["XLM"] => Ok(AssetIdentifier::Native),
+        [code, issuer] if code.len() <= 4 => Ok(AssetIdentifier::alphanum4(code, issuer)),
+        [code, issuer] if code.len() <= 12 => Ok(AssetIdentifier::alphanum12(code, issuer)),
+        _ => Err(InvalidInputError::from_str(
+            "Asset identifier not of the form <asset_code>-<asset_issuer>",
+        )),
     }
 }
 

--- a/client/src/endpoint/account.rs
+++ b/client/src/endpoint/account.rs
@@ -225,9 +225,8 @@ impl IntoRequest for Transactions {
 
 impl TryFromUri for Transactions {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"accounts"), Some(account_id), Some(&"transactions")) => {
+        match wrap.path() {
+            ["accounts", account_id, "transactions"] => {
                 let params = wrap.params();
                 Ok(Self {
                     account_id: account_id.to_string(),
@@ -380,9 +379,8 @@ impl IntoRequest for Effects {
 
 impl TryFromUri for Effects {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"accounts"), Some(account_id), Some(&"effects")) => {
+        match wrap.path() {
+            ["accounts", account_id, "effects"] => {
                 let params = wrap.params();
                 Ok(Self {
                     account_id: account_id.to_string(),
@@ -535,9 +533,8 @@ impl IntoRequest for Operations {
 
 impl TryFromUri for Operations {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"accounts"), Some(account_id), Some(&"operations")) => {
+        match wrap.path() {
+            ["accounts", account_id, "operations"] => {
                 let params = wrap.params();
                 Ok(Self {
                     account_id: account_id.to_string(),
@@ -683,9 +680,8 @@ impl IntoRequest for Payments {
 
 impl TryFromUri for Payments {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"accounts"), Some(account_id), Some(&"payments")) => {
+        match wrap.path() {
+            ["accounts", account_id, "payments"] => {
                 let params = wrap.params();
                 Ok(Self {
                     account_id: account_id.to_string(),
@@ -828,9 +824,8 @@ impl IntoRequest for Offers {
 
 impl TryFromUri for Offers {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"accounts"), Some(account_id), Some(&"offers")) => {
+        match wrap.path() {
+            ["accounts", account_id, "offers"] => {
                 let params = wrap.params();
                 Ok(Self {
                     account_id: account_id.to_string(),

--- a/client/src/endpoint/ledger.rs
+++ b/client/src/endpoint/ledger.rs
@@ -268,9 +268,8 @@ impl IntoRequest for Payments {
 
 impl TryFromUri for Payments {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"ledgers"), Some(sequence), Some(&"payments")) => {
+        match wrap.path() {
+            ["ledgers", sequence, "payments"] => {
                 let params = wrap.params();
                 Ok(Self {
                     sequence: sequence.parse()?,
@@ -410,9 +409,8 @@ impl IntoRequest for Transactions {
 
 impl TryFromUri for Transactions {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"ledgers"), Some(sequence), Some(&"transactions")) => {
+        match wrap.path() {
+            ["ledgers", sequence, "transactions"] => {
                 let params = wrap.params();
                 Ok(Self {
                     sequence: sequence.parse()?,
@@ -554,9 +552,8 @@ impl IntoRequest for Effects {
 
 impl TryFromUri for Effects {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"ledgers"), Some(sequence), Some(&"effects")) => {
+        match wrap.path() {
+            ["ledgers", sequence, "effects"] => {
                 let params = wrap.params();
                 Ok(Self {
                     sequence: sequence.parse()?,
@@ -698,9 +695,8 @@ impl IntoRequest for Operations {
 
 impl TryFromUri for Operations {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"ledgers"), Some(sequence), Some(&"operations")) => {
+        match wrap.path() {
+            ["ledgers", sequence, "operations"] => {
                 let params = wrap.params();
                 Ok(Self {
                     sequence: sequence.parse()?,

--- a/client/src/endpoint/operation.rs
+++ b/client/src/endpoint/operation.rs
@@ -280,9 +280,8 @@ impl IntoRequest for Effects {
 
 impl TryFromUri for Effects {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"operations"), Some(id), Some(&"effects")) => {
+        match wrap.path() {
+            ["operations", id, "effects"] => {
                 let params = wrap.params();
                 Ok(Self {
                     id: id.parse()?,

--- a/client/src/endpoint/transaction.rs
+++ b/client/src/endpoint/transaction.rs
@@ -255,9 +255,8 @@ impl IntoRequest for Effects {
 
 impl TryFromUri for Effects {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"transactions"), Some(hash), Some(&"effects")) => {
+        match wrap.path() {
+            ["transactions", hash, "effects"] => {
                 let params = wrap.params();
                 Ok(Self {
                     hash: hash.to_string(),
@@ -394,9 +393,8 @@ impl IntoRequest for Payments {
 
 impl TryFromUri for Payments {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"transactions"), Some(hash), Some(&"payments")) => {
+        match wrap.path() {
+            ["transactions", hash, "payments"] => {
                 let params = wrap.params();
                 Ok(Self {
                     hash: hash.to_string(),
@@ -530,9 +528,8 @@ impl IntoRequest for Operations {
 
 impl TryFromUri for Operations {
     fn try_from_wrap(wrap: &UriWrap) -> ::std::result::Result<Self, uri::Error> {
-        let path = wrap.path();
-        match (path.get(0), path.get(1), path.get(2)) {
-            (Some(&"transactions"), Some(hash), Some(&"operations")) => {
+        match wrap.path() {
+            ["transactions", hash, "operations"] => {
                 let params = wrap.params();
                 Ok(Self {
                     hash: hash.to_string(),


### PR DESCRIPTION
In a few places we were matching on the shape of an array. With the new
functionality in 1.26 we can match event more explicitly!

### Is there a GIF that reflects how this work made you feel?
![wow](https://user-images.githubusercontent.com/2043529/39935625-81534954-54fe-11e8-84d6-30402e3e3345.gif)
