### PR TITLE
Uses 1.26.1 cargo fmt

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -2,7 +2,7 @@ use super::{cursor, ordering, pager::Pager};
 use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
-use stellar_client::{sync, endpoint::account, sync::Client};
+use stellar_client::{endpoint::account, sync, sync::Client};
 
 pub fn data(client: &Client, matches: &ArgMatches) -> Result<()> {
     let id = matches.value_of("ID").expect("ID is required");

--- a/cli/src/assets.rs
+++ b/cli/src/assets.rs
@@ -2,7 +2,8 @@ use super::{cursor, ordering, pager::Pager};
 use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
-use stellar_client::{endpoint::asset, sync::{self, Client}};
+use stellar_client::{endpoint::asset,
+                     sync::{self, Client}};
 
 /// Using a client and the arguments from the command line, iterates over the results
 /// and displays them to the end user.

--- a/cli/src/effects.rs
+++ b/cli/src/effects.rs
@@ -2,7 +2,8 @@ use super::{cursor, ordering, pager::Pager};
 use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
-use stellar_client::{endpoint::effect, sync::{self, Client}};
+use stellar_client::{endpoint::effect,
+                     sync::{self, Client}};
 
 /// Using a client and the arguments from the command line, iterates over the results
 /// and displays them to the end user.

--- a/cli/src/fmt/simple/effect.rs
+++ b/cli/src/fmt/simple/effect.rs
@@ -1,6 +1,7 @@
 use super::Simple;
 use fmt::Render;
-use stellar_client::resources::{AssetIdentifier, effect::{Effect, EffectKind as Kind}};
+use stellar_client::resources::{effect::{Effect, EffectKind as Kind},
+                                AssetIdentifier};
 
 impl Render<Effect> for Simple {
     fn render(&self, effect: &Effect) -> Option<String> {

--- a/cli/src/fmt/simple/operation.rs
+++ b/cli/src/fmt/simple/operation.rs
@@ -1,6 +1,6 @@
 use super::Simple;
 use fmt::Render;
-use stellar_client::resources::{OperationKind as Kind, operation::*};
+use stellar_client::resources::{operation::*, OperationKind as Kind};
 
 impl Render<Operation> for Simple {
     fn render(&self, op: &Operation) -> Option<String> {

--- a/cli/src/ledgers.rs
+++ b/cli/src/ledgers.rs
@@ -2,7 +2,8 @@ use super::{cursor, ordering, pager::Pager};
 use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
-use stellar_client::{endpoint::ledger, sync::{self, Client}};
+use stellar_client::{endpoint::ledger,
+                     sync::{self, Client}};
 
 pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);

--- a/cli/src/operations.rs
+++ b/cli/src/operations.rs
@@ -2,7 +2,8 @@ use super::{cursor, ordering, pager::Pager};
 use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
-use stellar_client::{endpoint::operation, sync::{self, Client}};
+use stellar_client::{endpoint::operation,
+                     sync::{self, Client}};
 
 pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);

--- a/cli/src/orderbook.rs
+++ b/cli/src/orderbook.rs
@@ -2,7 +2,8 @@ use asset_identifier;
 use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
-use stellar_client::{endpoint::{orderbook, Limit}, sync::Client};
+use stellar_client::{endpoint::{orderbook, Limit},
+                     sync::Client};
 
 pub fn details(client: &Client, matches: &ArgMatches) -> Result<()> {
     let endpoint = {

--- a/cli/src/ordering.rs
+++ b/cli/src/ordering.rs
@@ -1,5 +1,6 @@
 use clap::{App, Arg, ArgMatches};
-use stellar_client::endpoint::{Direction::{Asc, Desc}, Order};
+use stellar_client::endpoint::{Direction::{Asc, Desc},
+                               Order};
 
 static ARG_NAME: &'static str = "order";
 static ASC: &'static str = "asc";

--- a/cli/src/payments.rs
+++ b/cli/src/payments.rs
@@ -2,7 +2,8 @@ use super::{cursor, ordering, pager::Pager};
 use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
-use stellar_client::{endpoint::payment, sync::{self, Client}};
+use stellar_client::{endpoint::payment,
+                     sync::{self, Client}};
 
 pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);

--- a/cli/src/trades.rs
+++ b/cli/src/trades.rs
@@ -5,7 +5,8 @@ use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
 use resolution::Resolution;
-use stellar_client::{endpoint::trade, sync::{self, Client}};
+use stellar_client::{endpoint::trade,
+                     sync::{self, Client}};
 
 pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -2,7 +2,8 @@ use super::{cursor, ordering, pager::Pager};
 use clap::ArgMatches;
 use error::Result;
 use fmt::{Formatter, Simple};
-use stellar_client::{endpoint::transaction, sync::{self, Client}};
+use stellar_client::{endpoint::transaction,
+                     sync::{self, Client}};
 
 pub fn all(client: &Client, matches: &ArgMatches) -> Result<()> {
     let pager = Pager::from_arg(&matches);

--- a/client/src/client/sync/mod.rs
+++ b/client/src/client/sync/mod.rs
@@ -14,12 +14,12 @@
 //! ```
 
 use super::{Host, HORIZON_TEST_URI, HORIZON_URI};
-use StellarError;
 use endpoint::IntoRequest;
 use error::{Error, Result};
 use http::{self, Uri};
 use reqwest;
 use serde_json;
+use StellarError;
 
 mod iter;
 

--- a/client/src/endpoint/order.rs
+++ b/client/src/endpoint/order.rs
@@ -1,4 +1,4 @@
-use std::{fmt, error::Error, str::FromStr, string::ToString};
+use std::{error::Error, fmt, str::FromStr, string::ToString};
 /// Declares that this endpoint has an order field and can have it set.
 ///
 /// ## Example

--- a/client/src/resources/effect/mod.rs
+++ b/client/src/resources/effect/mod.rs
@@ -1,4 +1,4 @@
-use resources::{Amount, AssetIdentifier, asset::Flags};
+use resources::{asset::Flags, Amount, AssetIdentifier};
 use serde::{de, Deserialize, Deserializer};
 
 pub mod account;
@@ -437,8 +437,7 @@ impl<'de> Deserialize<'de> for Effect {
                 } => {
                     let flags = Flags::new(auth_required_flag, auth_revokable_flag);
                     Kind::Account(account::Kind::FlagsUpdated(account::FlagsUpdated::new(
-                        account,
-                        flags,
+                        account, flags,
                     )))
                 }
                 _ => {
@@ -475,9 +474,7 @@ impl<'de> Deserialize<'de> for Effect {
                     weight: Some(weight),
                     ..
                 } => Kind::Signer(signer::Kind::Created(signer::Created::new(
-                    account,
-                    public_key,
-                    weight,
+                    account, public_key, weight,
                 ))),
                 _ => {
                     return Err(de::Error::custom(
@@ -492,9 +489,7 @@ impl<'de> Deserialize<'de> for Effect {
                     weight: Some(weight),
                     ..
                 } => Kind::Signer(signer::Kind::Removed(signer::Removed::new(
-                    account,
-                    public_key,
-                    weight,
+                    account, public_key, weight,
                 ))),
                 _ => {
                     return Err(de::Error::custom(
@@ -509,9 +504,7 @@ impl<'de> Deserialize<'de> for Effect {
                     weight: Some(weight),
                     ..
                 } => Kind::Signer(signer::Kind::Updated(signer::Updated::new(
-                    account,
-                    public_key,
-                    weight,
+                    account, public_key, weight,
                 ))),
                 _ => {
                     return Err(de::Error::custom(

--- a/client/src/resources/effect/test.rs
+++ b/client/src/resources/effect/test.rs
@@ -1,7 +1,8 @@
-use resources::{Amount, asset::Flags,
-                effect::{Effect, EffectKind, account::Kind as AccountKind,
-                         data::Kind as DataKind, signer::Kind as SignerKind,
-                         trade::Kind as TradeKind, trustline::Kind as TrustlineKind}};
+use resources::{asset::Flags,
+                effect::{account::Kind as AccountKind, data::Kind as DataKind,
+                         signer::Kind as SignerKind, trade::Kind as TradeKind,
+                         trustline::Kind as TrustlineKind, Effect, EffectKind},
+                Amount};
 use serde_json;
 
 fn account_created_json() -> &'static str {

--- a/client/src/resources/operation/create_passive_offer.rs
+++ b/client/src/resources/operation/create_passive_offer.rs
@@ -1,4 +1,4 @@
-use resources::{Amount, AssetIdentifier, offer::PriceRatio};
+use resources::{offer::PriceRatio, Amount, AssetIdentifier};
 
 /// “Create Passive Offer” operation creates an offer that won’t consume a counter offer that
 /// exactly matches this offer. This is useful for offers just used as 1:1 exchanges for path

--- a/client/src/resources/operation/manage_offer.rs
+++ b/client/src/resources/operation/manage_offer.rs
@@ -1,4 +1,4 @@
-use resources::{Amount, AssetIdentifier, offer::PriceRatio};
+use resources::{offer::PriceRatio, Amount, AssetIdentifier};
 
 /// A “Manage Offer” operation can create, update or delete an offer to trade assets in the Stellar
 /// network. It specifies an issuer, a price and amount of a given asset to buy or sell.

--- a/client/src/resources/operation/mod.rs
+++ b/client/src/resources/operation/mod.rs
@@ -1,5 +1,5 @@
 use super::deserialize;
-use resources::{Amount, AssetIdentifier, asset::Flags, offer::PriceRatio};
+use resources::{asset::Flags, offer::PriceRatio, Amount, AssetIdentifier};
 use serde::{de, Deserialize, Deserializer};
 mod account_merge;
 mod allow_trust;

--- a/client/src/resources/operation/test.rs
+++ b/client/src/resources/operation/test.rs
@@ -1,4 +1,4 @@
-use resources::{Amount, Operation, OperationKind, asset::Flags};
+use resources::{asset::Flags, Amount, Operation, OperationKind};
 use serde_json;
 
 fn account_merge_json() -> &'static str {
@@ -8,7 +8,6 @@ fn account_merge_json() -> &'static str {
 mod errors_on_missing_fields_for_type {
     use super::*;
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
     macro_rules! assert_err_on_missing_fields {
         ($type_to_check:ident, $type_i:expr) => {
             #[test]

--- a/client/src/resources/orderbook.rs
+++ b/client/src/resources/orderbook.rs
@@ -1,4 +1,4 @@
-use resources::{AssetIdentifier, offer::OfferSummary};
+use resources::{offer::OfferSummary, AssetIdentifier};
 
 /// Order books keep records of all offers to sell (asks)
 /// and offer to buy (bids) for a particular pair of assets.

--- a/client/src/resources/transaction.rs
+++ b/client/src/resources/transaction.rs
@@ -1,4 +1,4 @@
-use super::{deserialize, amount::Amount};
+use super::{amount::Amount, deserialize};
 use chrono::prelude::*;
 
 /// Memos are a useful source for adding meta data to a transaction.


### PR DESCRIPTION
The changes in 1.26.1 fix a bug that caused cargo fmt to continuously
indent some piece of code. Updating allowed the disabling to be removed.

### Is there a GIF that reflects how this work made you feel?
![frustrating](https://user-images.githubusercontent.com/2043529/40674430-adb4ce1c-6329-11e8-8d41-7144925a8021.gif)
