### PR TITLE
Fixes tiny error in docucomments regarding the horizon() fns

### DIFF
--- a/client/src/client/async.rs
+++ b/client/src/client/async.rs
@@ -80,7 +80,7 @@ impl Client {
         self.host == Host::HorizonTest
     }
 
-    /// Constructs a new stellar client connected to the horizon test network.
+    /// Constructs a new stellar client connected to the horizon prod network.
     ///
     /// ## Examples
     ///

--- a/client/src/client/sync/mod.rs
+++ b/client/src/client/sync/mod.rs
@@ -81,7 +81,7 @@ impl Client {
         self.host == Host::HorizonTest
     }
 
-    /// Constructs a new stellar client connected to the horizon test network.
+    /// Constructs a new stellar client connected to the horizon prod network.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
Hi there! I came across this project and was browsing the source when I noticed that the documentation strings for the non-test connection fns were erroneous. This tiny PR fixes that.
